### PR TITLE
apply a single DocumentHead to the root layout component

### DIFF
--- a/frontend/src/routes/explore/index.tsx
+++ b/frontend/src/routes/explore/index.tsx
@@ -1,5 +1,4 @@
 import { component$ } from '@builder.io/qwik'
-import { DocumentHead } from '@builder.io/qwik-city'
 import Explore from './Explore'
 
 export { statusesLoader } from './Explore'
@@ -7,13 +6,3 @@ export { statusesLoader } from './Explore'
 export default component$(() => {
 	return <Explore />
 })
-
-export const head: DocumentHead = {
-	title: 'Wildebeest (Mastodon on Cloudflare)',
-	meta: [
-		{
-			name: 'description',
-			content: 'A frontend for a mastodon server deployed on Cloudflare.',
-		},
-	],
-}

--- a/frontend/src/routes/first-login/index.tsx
+++ b/frontend/src/routes/first-login/index.tsx
@@ -1,5 +1,4 @@
 import { component$ } from '@builder.io/qwik'
-import { DocumentHead } from '@builder.io/qwik-city'
 import { MastodonLogo } from '~/components/MastodonLogo'
 import { useDomain } from '~/utils/useDomain'
 
@@ -46,13 +45,3 @@ export default component$(() => {
 		</div>
 	)
 })
-
-export const head: DocumentHead = {
-	title: 'Wildebeest (Mastodon on Cloudflare)',
-	meta: [
-		{
-			name: 'description',
-			content: 'A frontend for a mastodon server deployed on Cloudflare.',
-		},
-	],
-}

--- a/frontend/src/routes/layout.tsx
+++ b/frontend/src/routes/layout.tsx
@@ -1,5 +1,5 @@
 import { component$, useStylesScoped$, Slot } from '@builder.io/qwik'
-import { useLocation } from '@builder.io/qwik-city'
+import { DocumentHead, useLocation } from '@builder.io/qwik-city'
 import styles from './layout.scss?inline'
 import { LeftColumn } from './LeftColumn/LeftColumn'
 import { RightColumn } from './RightColumn/RightColumn'
@@ -41,3 +41,13 @@ export default component$(() => {
 		</main>
 	)
 })
+
+export const head: DocumentHead = {
+	title: 'Wildebeest (Mastodon on Cloudflare)',
+	meta: [
+		{
+			name: 'description',
+			content: 'A frontend for a mastodon server deployed on Cloudflare.',
+		},
+	],
+}

--- a/frontend/src/routes/start-instance/index.tsx
+++ b/frontend/src/routes/start-instance/index.tsx
@@ -1,5 +1,4 @@
 import { $, component$, useStore, useClientEffect$, useSignal } from '@builder.io/qwik'
-import { DocumentHead } from '@builder.io/qwik-city'
 import { MastodonLogo } from '~/components/MastodonLogo'
 import { useDomain } from '~/utils/useDomain'
 import Step1 from './step-1'
@@ -64,13 +63,3 @@ export default component$(() => {
 		</div>
 	)
 })
-
-export const head: DocumentHead = {
-	title: 'Wildebeest (Mastodon on Cloudflare)',
-	meta: [
-		{
-			name: 'description',
-			content: 'A frontend for a mastodon server deployed on Cloudflare.',
-		},
-	],
-}


### PR DESCRIPTION
currently we get the title (and description) only in the explore page and the first-login and start-instance ones, so I am moving the DocumentHead to the root layout so that we get the title in all the pages (and if a page needs a different one it can export a different DocumentHead)