### PR TITLE
fix: normalise uppercase github usernames

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,14 @@ jobs:
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
           CF_DEPLOY_DOMAIN: ${{ secrets.CF_DEPLOY_DOMAIN }}
 
+      # this is needed to get the lowercase version of the actor name
+      # TODO: switch to some lowercase function in the future when Actions supports it
+      - name: Set lowercase actor name
+        run: |
+          echo "ACTOR_LOWER=${GH_ACTOR,,}" >>${GITHUB_ENV}
+        env:
+          GH_ACTOR: ${{ github.actor }}
+
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v2
 
@@ -39,7 +47,7 @@ jobs:
       - name: Create D1 database
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          command: d1 create wildebeest-${{ github.actor }}
+          command: d1 create wildebeest-${{ ACTOR_LOWER }}
           apiToken: ${{ secrets.CF_API_TOKEN }}
         continue-on-error: true
         env:
@@ -48,7 +56,7 @@ jobs:
       - name: retrieve D1 database
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          command: d1 list | grep wildebeest-${{ github.actor }} | awk '{print "d1_id="$2}' >> $GITHUB_ENV
+          command: d1 list | grep wildebeest-${{ ACTOR_LOWER }} | awk '{print "d1_id="$2}' >> $GITHUB_ENV
           apiToken: ${{ secrets.CF_API_TOKEN }}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -56,11 +64,11 @@ jobs:
       - name: migrate D1 database
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          command: d1 migrations apply wildebeest-${{ github.actor }}
+          command: d1 migrations apply wildebeest-${{ ACTOR_LOWER }}
           apiToken: ${{ secrets.CF_API_TOKEN }}
           preCommands: |
             echo "*** pre commands ***"
-            echo -e "[[d1_databases]]\nbinding=\"DATABASE\"\ndatabase_name=\"wildebeest-${{ github.actor }}\"\ndatabase_id=\"${{ env.d1_id }}\"" >> wrangler.toml
+            echo -e "[[d1_databases]]\nbinding=\"DATABASE\"\ndatabase_name=\"wildebeest-${{ ACTOR_LOWER }}\"\ndatabase_id=\"${{ env.d1_id }}\"" >> wrangler.toml
             echo "******"
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -84,7 +92,7 @@ jobs:
           TF_VAR_cloudflare_api_token: ${{ secrets.CF_API_TOKEN }}
           TF_VAR_cloudflare_zone_id: ${{ secrets.CF_ZONE_ID }}
           TF_VAR_cloudflare_deploy_domain: ${{ secrets.CF_DEPLOY_DOMAIN }}
-          TF_VAR_gh_username: ${{ github.actor }}
+          TF_VAR_gh_username: ${{ ACTOR_LOWER }}
           TF_VAR_d1_id: ${{ env.d1_id }}
           TF_VAR_access_auth_domain: ${{ env.auth_domain }}
 
@@ -98,6 +106,6 @@ jobs:
             yarn build
             cp -rv ./frontend/dist/* .
             echo "******"
-          command: pages publish --project-name=wildebeest-${{ github.actor }} .
+          command: pages publish --project-name=wildebeest-${{ ACTOR_LOWER }} .
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -46,7 +46,7 @@ provider "cloudflare" {
 
 resource "cloudflare_workers_kv_namespace" "wildebeest_cache" {
   account_id = var.cloudflare_account_id
-  title = "wildebeest-${var.gh_username}-cache"
+  title = "wildebeest-${lower(var.gh_username)}-cache"
 }
 
 resource "random_password" "user_key" {
@@ -56,7 +56,7 @@ resource "random_password" "user_key" {
 
 resource "cloudflare_pages_project" "wildebeest_pages_project" {
   account_id = var.cloudflare_account_id
-  name              = "wildebeest-${var.gh_username}"
+  name              = "wildebeest-${lower(var.gh_username)}"
   production_branch = "main"
 
   deployment_configs {
@@ -92,7 +92,7 @@ resource "cloudflare_record" "record" {
 
 resource "cloudflare_pages_domain" "domain" {
   account_id   = var.cloudflare_account_id
-  project_name = "wildebeest-${var.gh_username}"
+  project_name = "wildebeest-${lower(var.gh_username)}"
   domain       = var.cloudflare_deploy_domain
 
   depends_on = [
@@ -103,7 +103,7 @@ resource "cloudflare_pages_domain" "domain" {
 
 resource "cloudflare_access_application" "wildebeest_access" {
   account_id                = var.cloudflare_account_id
-  name                      = "wildebeest-${var.gh_username}"
+  name                      = "wildebeest-${lower(var.gh_username)}"
   domain                    = "${var.cloudflare_deploy_domain}/oauth/authorize"
   type                      = "self_hosted"
   session_duration          = "168h"


### PR DESCRIPTION
This normalises the GitHub username in both the Action and Terraform config to lowercase. Terraform nicely supports `lower()` but GitHub Actions don't have a nice way to do this. I used the solution proposed at https://github.com/orgs/community/discussions/27086#discussioncomment-3254548 but would welcome any feedback.

Resolves #36 