### PR TITLE
terraform: explicitly disable auto minify of JS

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -135,7 +135,7 @@ resource "cloudflare_ruleset" "wildebeest_config_rules" {
         "js": false
       }
     }
-    expression  = "(http.host eq \"${cloudflare_deploy_domain}\")"
+    expression  = "(http.host eq \"${trimspace(var.cloudflare_deploy_domain)}\")"
     description = "Disable JS minification for the Mastodon subdomain"
     enabled     = true
   }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -136,7 +136,7 @@ resource "cloudflare_ruleset" "wildebeest_config_rules" {
       }
     }
     expression  = "(http.host eq \"${trimspace(var.cloudflare_deploy_domain)}\")"
-    description = "Disable JS minification for the Mastodon subdomain"
+    description = "Disable JS minification for the Wildebeest subdomain"
     enabled     = true
   }
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -135,7 +135,7 @@ resource "cloudflare_ruleset" "wildebeest_config_rules" {
         "js": false
       }
     }
-    expression  = "(http.host eq \"${cloudflare_deploy_domain}\""
+    expression  = "(http.host eq \"${cloudflare_deploy_domain}\")"
     description = "Disable JS minification for the Mastodon subdomain"
     enabled     = true
   }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -122,14 +122,21 @@ resource "cloudflare_access_policy" "policy" {
   }
 }
 
-resource "cloudflare_zone_settings_override" "wildebeest_zone_config" {
-    zone_id = var.cloudflare_zone_id
-    settings {
-        brotli = "on"
-        minify {
-            css = "on"
-            js = "off"
-            html = "off"
-        }
+resource "cloudflare_ruleset" "wildebeest_config_rules" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "Config rules ruleset"
+  kind        = "zone"
+  phase       = "http_config_settings"
+
+  rules {
+    action = "set_config"
+    action_parameters {
+      "autominify": {
+        "js": false
+      }
     }
+    expression  = "(http.host eq \"${cloudflare_deploy_domain}\""
+    description = "Disable JS minification for the Mastodon subdomain"
+    enabled     = true
+  }
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -121,3 +121,15 @@ resource "cloudflare_access_policy" "policy" {
     email = ["CHANGEME@example.com"]
   }
 }
+
+resource "cloudflare_zone_settings_override" "wildebeest_zone_config" {
+    zone_id = var.cloudflare_zone_id
+    settings {
+        brotli = "on"
+        minify {
+            css = "on"
+            js = "off"
+            html = "off"
+        }
+    }
+}


### PR DESCRIPTION
Auto-minify breaks the Mastodon front-end. This explicitly sets the zone config to disable it.

Ref: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_settings_override

