### PR TITLE
Use Pleroma-compatible version string

### DIFF
--- a/functions/api/v1/instance.ts
+++ b/functions/api/v1/instance.ts
@@ -1,6 +1,7 @@
 import type { Env } from 'wildebeest/backend/src/types/env'
 
-const INSTANCE_VERSION = '4.0.2'
+export const INSTANCE_VERSION = '0.0.0'
+export const COMPAT_VERSION = '4.0.2'
 
 export const onRequest: PagesFunction<Env, any> = async ({ env, request }) => {
 	const domain = new URL(request.url).hostname
@@ -34,7 +35,7 @@ export async function handleRequest(domain: string, db: D1Database) {
 	// should go through the login flow and authenticate with Access.
 	// The documentation is incorrect and registrations is a boolean.
 	res.registrations = false
-	res.version = INSTANCE_VERSION
+	res.version = `${COMPAT_VERSION} (compatible; Wildebeest ${INSTANCE_VERSION})`
 	res.rules = []
 	res.uri = domain
 

--- a/functions/api/v2/instance.ts
+++ b/functions/api/v2/instance.ts
@@ -1,7 +1,7 @@
+import { COMPAT_VERSION, INSTANCE_VERSION } from 'wildebeest/functions/api/v1/instance'
+
 import type { Env } from 'wildebeest/backend/src/types/env'
 import type { InstanceConfigV2 } from 'wildebeest/backend/src/types/configs'
-
-const INSTANCE_VERSION = '4.0.2'
 
 export const onRequest: PagesFunction<Env, any> = async ({ env, request }) => {
 	const domain = new URL(request.url).hostname
@@ -34,7 +34,7 @@ export async function handleRequest(domain: string, db: D1Database) {
 	const res: InstanceConfigV2 = {
 		domain,
 		title: config.title,
-		version: INSTANCE_VERSION,
+		version: `${COMPAT_VERSION} (compatible; Wildebeest ${INSTANCE_VERSION})`,
 		source_url: 'https://github.com/cloudflare/wildebeest',
 		description: config.description,
 		thumbnail: {


### PR DESCRIPTION
As documented here: https://gitlab.com/soapbox-pub/soapbox/-/blob/develop/docs/development/developing-backend.md

This is implemented by other non-Mastodon backends utilizing Mastodon API, including Pixelfed, Pleroma, Mitra, Friendica…