### PR TITLE
add page not found

### DIFF
--- a/frontend/src/routes/(frontend)/[accountId]/[...]/index.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/[...]/index.tsx
@@ -1,0 +1,11 @@
+import { component$ } from '@builder.io/qwik'
+import { loader$ } from '@builder.io/qwik-city'
+
+export const loader = loader$(({ redirect }) => {
+	redirect(303, '/not-found')
+})
+
+export default component$(() => {
+	loader.use()
+	return <></>
+})

--- a/frontend/src/routes/(frontend)/[accountId]/[statusId]/index.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/[statusId]/index.tsx
@@ -11,10 +11,12 @@ import { Avatar } from '~/components/avatar'
 export const statusLoader = loader$<
 	{ DATABASE: D1Database; domain: string },
 	Promise<{ status: MastodonStatus; context: StatusContext }>
->(async ({ platform, params }) => {
+>(async ({ redirect, platform, params }) => {
 	const response = await statusAPI.handleRequest(platform.DATABASE, params.statusId)
 	const results = await response.text()
-	// Manually parse the JSON to ensure that Qwik finds the resulting objects serializable.
+	if (!results) {
+		throw redirect(303, '/not-found')
+	}
 	return { status: JSON.parse(results), context: { ancestors: [], descendants: [] } }
 })
 

--- a/frontend/src/routes/(frontend)/[accountId]/index.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/index.tsx
@@ -1,8 +1,22 @@
 import { component$ } from '@builder.io/qwik'
-import { useLocation } from '@builder.io/qwik-city'
+import { loader$ } from '@builder.io/qwik-city'
+
+export const accountLoader = loader$(({ redirect, request }) => {
+	const params = new URL(request.url).searchParams
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const accountId = params.get('accountId')
+
+	redirect(303, '/not-found')
+
+	// TODO: retrieve the account details from the backend
+	const accountDetails = null
+
+	return accountDetails
+})
 
 export default component$(() => {
-	const location = useLocation()
+	const accountDetails = accountLoader.use()
 
-	return <div>account details {location.params.accountId}</div>
+	// TODO: Implement the account view
+	return <>{accountDetails.value && <div>account details</div>}</>
 })

--- a/frontend/src/routes/not-found/index.tsx
+++ b/frontend/src/routes/not-found/index.tsx
@@ -1,0 +1,22 @@
+import { component$ } from '@builder.io/qwik'
+import { DocumentHead } from '@builder.io/qwik-city'
+
+export default component$(() => {
+	return (
+		<div class="h-screen w-screen bg-wildebeest-600 grid place-items-center">
+			<h1 class="text-wildebeest-200 text-xl text-center mx-5">The page you are looking for isn't here.</h1>
+		</div>
+	)
+})
+
+export const head: DocumentHead = () => {
+	return {
+		title: 'Wildebeest Not Found',
+		meta: [
+			{
+				name: 'description',
+				content: 'Wildebeest Page Not Found',
+			},
+		],
+	}
+}


### PR DESCRIPTION
Adding a 404 page:
![Screenshot 2023-01-12 at 15 37 58](https://user-images.githubusercontent.com/61631103/212112498-d5c56034-6600-4b12-8807-d54b37fa94b8.png)

I've copied mastodon 404 page but without an image:
![Screenshot 2023-01-12 at 15 38 17](https://user-images.githubusercontent.com/61631103/212112591-bcb0b9a9-8ce2-4aa1-87f3-ddabed4f72be.png)

___

The routes all work like mastodon, the only difference with mastodon is that here I am redirecting to `/not-found` when a page is not found instead of keeping the same location but displaying the 404 page. This implementation is cleaner and simpler, but if we prefer to follow more closely mastodon I can implement it in the same way they do
