### PR TITLE
Add oauth state param

### DIFF
--- a/backend/test/mastodon/oauth.spec.ts
+++ b/backend/test/mastodon/oauth.spec.ts
@@ -84,6 +84,7 @@ describe('Mastodon APIs', () => {
 				redirect_uri: client.redirect_uris,
 				response_type: 'code',
 				client_id: client.id,
+				state: 'mock-state',
 			})
 
 			const headers = { 'Cf-Access-Jwt-Assertion': TEST_JWT }
@@ -97,7 +98,7 @@ describe('Mastodon APIs', () => {
 			const location = new URL(res.headers.get('location') || '')
 			assert.equal(
 				location.searchParams.get('redirect_uri'),
-				encodeURIComponent(`${client.redirect_uris}?code=${client.id}.${TEST_JWT}`)
+				encodeURIComponent(`${client.redirect_uris}?code=${client.id}.${TEST_JWT}&state=mock-state`)
 			)
 
 			// actor isn't created yet

--- a/functions/oauth/authorize.ts
+++ b/functions/oauth/authorize.ts
@@ -58,6 +58,8 @@ export async function handleRequestPost(
 		return new Response('', { status: 403 })
 	}
 
+	const state = url.searchParams.get('state')
+
 	const jwt = extractJWTFromRequest(request)
 	const validate = access.generateValidator({ jwt, domain: accessDomain, aud: accessAud })
 	await validate(request)
@@ -69,15 +71,17 @@ export async function handleRequestPost(
 
 	const code = `${client.id}.${jwt}`
 
+	const redirect = redirect_uri + `?code=${code}` + (state ? `&state=${state}` : '')
+
 	const person = await getPersonByEmail(db, identity.email)
 	if (person === null) {
 		url.pathname = '/first-login'
 		url.searchParams.set('email', identity.email)
-		url.searchParams.set('redirect_uri', encodeURIComponent(redirect_uri + '?code=' + code))
+		url.searchParams.set('redirect_uri', encodeURIComponent(redirect))
 		return URLsafeRedirect(url.toString())
 	}
 
-	return URLsafeRedirect(redirect_uri + '?code=' + code)
+	return URLsafeRedirect(redirect)
 }
 
 // Workaround bug EW-7148, constructing an URL with unknown protocols


### PR DESCRIPTION
Help preventing potential CSRF https://auth0.com/docs/secure/attack-protection/state-parameters. Also make it work for the clients that do check the `state` param.

Duplicate of https://github.com/cloudflare/wildebeest/pull/163