### PR TITLE
Add indices to outbox_objects

### DIFF
--- a/migrations/0004_add_outbox_objects_indices.sql
+++ b/migrations/0004_add_outbox_objects_indices.sql
@@ -1,0 +1,4 @@
+-- Migration number: 0004 	 2023-02-03T17:17:19.099Z
+
+CREATE INDEX IF NOT EXISTS outbox_objects_actor_id ON outbox_objects(actor_id);
+CREATE INDEX IF NOT EXISTS outbox_objects_target ON outbox_objects(target);


### PR DESCRIPTION
Allowing the public timeline to use the `outbox_objects_target` index.