### PR TITLE
replace wrong status-content with inner-html-content

### DIFF
--- a/frontend/src/routes/(frontend)/[accountId]/[statusId]/index.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/[statusId]/index.tsx
@@ -1,4 +1,4 @@
-import { component$, Slot } from '@builder.io/qwik'
+import { component$, Slot, useStyles$ } from '@builder.io/qwik'
 import { MastodonStatus, StatusContext } from '~/types'
 import Status from '~/components/Status'
 import { formatDateTime } from '~/utils/dateTime'
@@ -10,6 +10,7 @@ import StickyHeader from '~/components/StickyHeader/StickyHeader'
 import { Avatar } from '~/components/avatar'
 import { MediaGallery } from '~/components/MediaGallery.tsx'
 import { getNotFoundHtml } from '~/utils/getNotFoundHtml/getNotFoundHtml'
+import styles from '../../../../utils/innerHtmlContent.scss?inline'
 
 export const statusLoader = loader$<
 	{ DATABASE: D1Database },
@@ -31,6 +32,8 @@ export const statusLoader = loader$<
 })
 
 export default component$(() => {
+	useStyles$(styles)
+
 	const { status, context } = statusLoader.use().value
 
 	return (
@@ -45,7 +48,7 @@ export default component$(() => {
 			</StickyHeader>
 			<div class="bg-wildebeest-700 p-4">
 				<AccountCard status={status} />
-				<div class="leading-normal status-content text-lg" dangerouslySetInnerHTML={status.content} />
+				<div class="leading-normal inner-html-content text-lg" dangerouslySetInnerHTML={status.content} />
 
 				<MediaGallery medias={status.media_attachments} />
 


### PR DESCRIPTION
in #182 I replaced `status-content` with `inner-html-content` but I missed an instance :sweat: , fixing that now

<details>

before (notice the broken styling for the toot's content):
![before](https://user-images.githubusercontent.com/61631103/216779988-a1d0ef2f-78d9-4d39-8865-e2aec5fe2736.png)

after:
![Screenshot at 2023-02-04 16-59-57](https://user-images.githubusercontent.com/61631103/216779997-77fd9574-35cc-44f0-a6af-07d6c99cf098.png)


</details>