### PR TITLE
Change Default Images to Official Mastodon Avatar

### DIFF
--- a/config/accounts.ts
+++ b/config/accounts.ts
@@ -1,6 +1,5 @@
 import type { DefaultImages } from '../backend/src/types/configs'
-
 export const defaultImages: DefaultImages = {
-	avatar: 'https://masto.ai/avatars/original/missing.png',
+	avatar: 'https://raw.githubusercontent.com/mastodon/mastodon/main/public/avatars/original/missing.png',
 	header: 'https://imagedelivery.net/NkfPDviynOyTAOI79ar_GQ/b24caf12-5230-48c4-0bf7-2f40063bd400/header',
 }


### PR DESCRIPTION
Currently, Wildebeest uses the default Mastodon avatar hosted by masto.ai. This changes the default value to point to the official Mastodon project repository instead.

[X] Use the official Mastodon default image for avatar