### PR TITLE
Disjoint Link from Object

### DIFF
--- a/backend/src/activitypub/objects/link.ts
+++ b/backend/src/activitypub/objects/link.ts
@@ -1,6 +1,7 @@
-import type { APObject } from 'wildebeest/backend/src/activitypub/objects'
+// https://www.w3.org/TR/activitystreams-vocabulary/#dfn-link
+export interface Link {
+	type: string
 
-export interface Link extends APObject {
 	href: URL
 	name: string
 }

--- a/backend/src/activitypub/objects/mention.ts
+++ b/backend/src/activitypub/objects/mention.ts
@@ -2,14 +2,12 @@ import type { Link } from 'wildebeest/backend/src/activitypub/objects/link'
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
 
+// https://www.w3.org/TR/activitystreams-vocabulary/#dfn-mention
 export interface Mention extends Link {}
 
 export function newMention(actor: Actor): Mention {
 	return {
 		type: 'Mention',
-		id: actor.id,
-		url: actor.id,
-
 		href: actor.id,
 		name: urlToHandle(actor.id),
 	}


### PR DESCRIPTION
Link was extending Object which was a mistake (as pointed out in https://github.com/cloudflare/wildebeest/issues/35). This change disjoints Link and Object objects, as specified by https://www.w3.org/TR/activitystreams-vocabulary/#dfn-link.