### PR TITLE
Make /api/v1/accounts/[id]/statuses public

### DIFF
--- a/backend/src/middleware/main.ts
+++ b/backend/src/middleware/main.ts
@@ -58,6 +58,7 @@ export async function main(context: EventContext<Env, any, any>) {
 		url.pathname === '/.well-known/webfinger' ||
 		url.pathname === '/api/v1/trends/statuses' ||
 		url.pathname === '/api/v1/trends/links' ||
+		/^\/api\/v1\/accounts\/(.*)\/statuses$/.test(url.pathname) ||
 		url.pathname.startsWith('/api/v1/tags/') ||
 		url.pathname.startsWith('/api/v1/timelines/tag/') ||
 		url.pathname.startsWith('/ap/') // all ActivityPub endpoints


### PR DESCRIPTION
The endpoint supports both authentificated and public access. At the moment the connected user isn't used, we can just make the endpont public.

Closes https://github.com/cloudflare/wildebeest/issues/275