### PR TITLE
add CI=true to database:create-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"d1": "NO_D1_WARNING=true wrangler d1",
 		"pages": "NO_D1_WARNING=true wrangler pages",
 		"database:migrate": "yarn d1 migrations apply DATABASE",
-		"database:create-mock": "rm -f .wrangler/state/d1/DATABASE.sqlite3 && yarn database:migrate --local && node ./frontend/mock-db/run.mjs",
+		"database:create-mock": "rm -f .wrangler/state/d1/DATABASE.sqlite3 && CI=true yarn database:migrate --local && node ./frontend/mock-db/run.mjs",
 		"dev": "export COMMIT_HASH=$(git rev-parse HEAD) && yarn build && yarn database:migrate --local && yarn pages dev frontend/dist --d1 DATABASE --persist --compatibility-date=2022-12-20 --binding 'INSTANCE_DESCR=My Wildebeest Instance' --live-reload",
 		"ci-dev-test-ui": "yarn build && yarn database:create-mock && yarn pages dev frontend/dist --d1 DATABASE --persist --port 8788  --binding 'INSTANCE_DESCR=My Wildebeest Instance' --compatibility-date=2022-12-20",
 		"deploy:init": "yarn pages project create wildebeest && yarn d1 create wildebeest",


### PR DESCRIPTION
add CI=true to database:create-mock so that wrangler doesn't show a confirmation prompt asking the user if they want to apply the migrations (since at that point it is obvious they do)