### PR TITLE
fix: Changed line breaks so that text does not overflow

### DIFF
--- a/frontend/src/components/HtmlContent/HtmlContent.scss
+++ b/frontend/src/components/HtmlContent/HtmlContent.scss
@@ -16,6 +16,8 @@
 
 	:global(p) {
 		margin-bottom: theme('spacing.4');
+		overflow-wrap: break-word;
+		white-space: pre-wrap;
 	}
 
 	:global(.invisible) {

--- a/frontend/src/components/Status/index.tsx
+++ b/frontend/src/components/Status/index.tsx
@@ -24,7 +24,7 @@ export default component$((props: Props) => {
 	const handleContentClick = $(() => nav(statusUrl))
 
 	return (
-		<article class="p-4 border-t border-wildebeest-700 break-words sm:break-normal">
+		<article class="p-4 border-t border-wildebeest-700 break-words">
 			<RebloggerLink account={reblogger}></RebloggerLink>
 			<div class="flex justify-between mb-3">
 				<StatusAccountCard status={status} subText="username" secondaryAvatar={reblogger} />

--- a/frontend/src/routes/(frontend)/layout.tsx
+++ b/frontend/src/routes/(frontend)/layout.tsx
@@ -46,7 +46,7 @@ export default component$(() => {
 						<LeftColumn />
 					</div>
 				</div>
-				<div class="w-full xl:max-w-xl bg-wildebeest-600 xl:bg-transparent flex flex-col break-all sm:break-normal">
+				<div class="w-full xl:max-w-xl bg-wildebeest-600 xl:bg-transparent flex flex-col break-all">
 					<div class="bg-wildebeest-600 rounded flex flex-1 flex-col">
 						<Slot />
 					</div>


### PR DESCRIPTION
Thanks for the great project!

Changed the display of line breaks and spaces.

|  | Before | After |
| :--: | :--: | :--: |
| xl | ![xl-before](https://user-images.githubusercontent.com/3946829/219873712-6df2261e-3008-472e-9126-aafb6249ff2a.png) | ![xl-after](https://user-images.githubusercontent.com/3946829/219873778-e9f05dcb-cfd2-4ce2-b112-22a4a9ee463f.png) |
| md | ![md-before](https://user-images.githubusercontent.com/3946829/219873708-14ea8e6e-d663-4461-9bb9-3b400982ed93.png) | ![md-after](https://user-images.githubusercontent.com/3946829/219873777-fd44aa30-d2c9-41de-8c2e-b430214cf388.png) |
| sm | ![sm-before](https://user-images.githubusercontent.com/3946829/219873706-f903ca14-18d8-4fc2-bcd6-641ec9c5e338.png) | ![sm-after](https://user-images.githubusercontent.com/3946829/219873773-973d5795-3309-45da-9aab-8efcd6a96e5e.png) |