### PR TITLE
Fix federation with Pleroma

### DIFF
--- a/backend/src/utils/http-signing.ts
+++ b/backend/src/utils/http-signing.ts
@@ -27,9 +27,6 @@ export async function signRequest(request: Request, key: CryptoKey, keyId: URL):
 
 	await sign(request, {
 		components: components,
-		parameters: {
-			created: Math.floor(Date.now() / 1000),
-		},
 		keyId: keyId.toString(),
 		signer: mySigner,
 	})

--- a/backend/src/utils/httpsigjs/parser.ts
+++ b/backend/src/utils/httpsigjs/parser.ts
@@ -261,8 +261,8 @@ export function parseRequest(request: Request, options?: Options): ParsedSignatu
 
 	if (!parsed.params.signature) throw new InvalidHeaderError('signature was not specified')
 
-	if (['date', 'x-date', '(created)'].every((hdr) => parsedHeaders.indexOf(hdr) < 0)) {
-		throw new MissingHeaderError('no signed date header')
+	if (['date', 'x-date', '(created)', 'digest'].every((hdr) => parsedHeaders.indexOf(hdr) < 0)) {
+		throw new MissingHeaderError('no signed date or digest header')
 	}
 
 	// Check the algorithm against the official list


### PR DESCRIPTION
Fixes a problem where federation with Pleroma would result in 400 "Invalid signature"

Here's what Pleroma sees:

```
[debug] Signature: Wj/gSLT5Sy96i3XdgjoGSR+qvWH7VNZsc39SoLDTpAljBzrMZtvvEy4i0VIjUwXm3tGUwspit5MiTLUHTfTx5RNWr2LYDnxAc8ccKcL3SYWN+F+1M95IDaEUt4Mf3e81dLDcZ+gRT25fNJN2JaSO1hUvjQmoo6vq0h1TtAwUfxc=
[debug] Sigstring: (request-target): post /inbox
(created): 
host: localhost:4000
digest: SHA-256=35CqeIhRQcR4LWS+RmV85RXbJiG/R483vgy8SwlsVi0=
date: Sat, 18 Feb 2023 18:58:04 GMT
```

Notice `(created)` being blank.

Unfortunately, Pleroma only supports the `(request-target)` (and `@request-target`) pseudo-headers. This is not on purpose, it's a bug in the [http_signatures](https://git.pleroma.social/pleroma/elixir-libraries/http_signatures/-/blob/65aab775d7321140e71f552742b887e365717041/lib/http_signatures/http_signatures.ex#L74-77) library used to verify requests.

I don't think it's especially important to sign the `(created)` header when a Digest is available, so the best course of action is to remove it.

(P.S. I'm maintaining a Deno library with Wildebeest's HTTP signature code here: https://gitlab.com/soapbox-pub/fedisign )