### PR TITLE
Fix federation with Pleroma (take 2)

### DIFF
--- a/backend/src/utils/http-signing.ts
+++ b/backend/src/utils/http-signing.ts
@@ -15,21 +15,22 @@ export async function signRequest(request: Request, key: CryptoKey, keyId: URL):
 		)
 	mySigner.alg = 'hs2019' as Algorithm
 
+	if (!request.headers.has('Date')) {
+		request.headers.set('Date', new Date().toUTCString())
+	}
+
 	if (!request.headers.has('Host')) {
 		const url = new URL(request.url)
 		request.headers.set('Host', url.host)
 	}
 
-	const components = ['@request-target', 'host']
+	const components = ['@request-target', 'date', 'host']
 	if (request.method == 'POST') {
 		components.push('digest')
 	}
 
 	await sign(request, {
 		components: components,
-		parameters: {
-			created: Math.floor(Date.now() / 1000),
-		},
 		keyId: keyId.toString(),
 		signer: mySigner,
 	})


### PR DESCRIPTION
Supersedes https://github.com/cloudflare/wildebeest/pull/313, but I wanted to make a separate PR so the solutions could be easily compared. See the original for more context.

Pleroma has a bug where `(created)` is not an acceptable component to sign. This leads to a conundrum, because [`Date` is a "forbidden" header name according to the fetch spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date).

At the same time, Mastodon _requires_ that `Date` or `(created)` be part of the signature. So if you choose `(created)`, federation with Pleroma breaks. If you choose `Date`, you violate the fetch spec.

Trying to set `(created)` as an _actual_ header throws. But setting `Date` and removing `(created)` actually works.

I am running this code in Deno, not a Cloudflare worker. There I am able to set the `Date` header just fine, and federation works perfectly with Mastodon, Pleroma, and Misskey. I tested all 3 this time.