### PR TITLE
remove tabs and newlines from dummy status

### DIFF
--- a/frontend/src/dummyData/statuses.ts
+++ b/frontend/src/dummyData/statuses.ts
@@ -8,6 +8,7 @@ const mastodonRawStatuses: MastodonStatus[] = [
 		content: `
 		<p>Fine. I'll use Wildebeest!</p>
 		<p>It does look interesting:
+			&#32
 			<a href="https://blog.cloudflare.com/welcome-to-wildebeest-the-fediverse-on-cloudflare/"
 				target="_blank"
 				rel="nofollow noopener noreferrer">
@@ -15,7 +16,7 @@ const mastodonRawStatuses: MastodonStatus[] = [
 					<span class="ellipsis">blog.cloudflare.com/welcome-to</span>
 					<span class="invisible">-wildebeest-the-fediverse-on-cloudflare/</span>
 			</a>
-		</p>`,
+		</p>`.replace(/[\t\n]/g, ''),
 		account: george,
 	}),
 	generateDummyStatus({


### PR DESCRIPTION
As indicated in https://github.com/cloudflare/wildebeest/pull/312 statuses content can include spacing so this PR fixes one of our dummy statuses so that it doesn't contain extra spacing

before:
![Screenshot 2023-02-20 at 10 39 01](https://user-images.githubusercontent.com/61631103/220082383-736e9245-216d-484c-9ba7-8bb7d5101885.png)

after:
![Screenshot 2023-02-20 at 10 37 54](https://user-images.githubusercontent.com/61631103/220082397-af76c776-0ea9-462a-98ff-959e2411826c.png)
