### PR TITLE
use Actor properties for inbox URL

### DIFF
--- a/backend/src/activitypub/objects/note.ts
+++ b/backend/src/activitypub/objects/note.ts
@@ -2,7 +2,6 @@
 
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import type { Link } from 'wildebeest/backend/src/activitypub/objects/link'
-import { followersURL } from 'wildebeest/backend/src/activitypub/actors'
 import { PUBLIC_GROUP } from 'wildebeest/backend/src/activitypub/activities'
 import * as objects from '.'
 
@@ -36,7 +35,7 @@ export async function createPublicNote(
 		attributedTo: actorId,
 		content,
 		to: [PUBLIC_GROUP],
-		cc: [followersURL(actorId)],
+		cc: [actor.followers.toString()],
 
 		// FIXME: stub values
 		replies: null,

--- a/backend/test/activitypub.spec.ts
+++ b/backend/test/activitypub.spec.ts
@@ -31,7 +31,13 @@ describe('ActivityPub', () => {
 
 	test('fetch user by id', async () => {
 		const db = await makeDB()
-		const properties = { summary: 'test summary' }
+		const properties = {
+			summary: 'test summary',
+			inbox: 'https://example.com/inbox',
+			outbox: 'https://example.com/outbox',
+			following: 'https://example.com/following',
+			followers: 'https://example.com/followers',
+		}
 		const pubKey =
 			'-----BEGIN PUBLIC KEY-----MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApnI8FHJQXqqAdM87YwVseRUqbNLiw8nQ0zHBUyLylzaORhI4LfW4ozguiw8cWYgMbCufXMoITVmdyeTMGbQ3Q1sfQEcEjOZZXEeCCocmnYjK6MFSspjFyNw6GP0a5A/tt1tAcSlgALv8sg1RqMhSE5Kv+6lSblAYXcIzff7T2jh9EASnimaoAAJMaRH37+HqSNrouCxEArcOFhmFETadXsv+bHZMozEFmwYSTugadr4WD3tZd+ONNeimX7XZ3+QinMzFGOW19ioVHyjt3yCDU1cPvZIDR17dyEjByNvx/4N4Zly7puwBn6Ixy/GkIh5BWtL5VOFDJm/S+zcf1G1WsOAXMwKL4Nc5UWKfTB7Wd6voId7vF7nI1QYcOnoyh0GqXWhTPMQrzie4nVnUrBedxW0s/0vRXeR63vTnh5JrTVu06JGiU2pq2kvwqoui5VU6rtdImITybJ8xRkAQ2jo4FbbkS6t49PORIuivxjS9wPl7vWYazZtDVa5g/5eL7PnxOG3HsdIJWbGEh1CsG83TU9burHIepxXuQ+JqaSiKdCVc8CUiO++acUqKp7lmbYR9E/wRmvxXDFkxCZzA0UL2mRoLLLOe4aHvRSTsqiHC5Wwxyew5bb+eseJz3wovid9ZSt/tfeMAkCDmaCxEK+LGEbJ9Ik8ihis8Esm21N0A54sCAwEAAQ==-----END PUBLIC KEY-----'
 		await db


### PR DESCRIPTION
Previously the inbox URL would be guessed from Mastodon URL scheme, however this doesn't work with non Mastodon Actors.

This change relies on Actor's properties to get the inbox URL, ie the proper way.