### PR TITLE
Changed to use getErrorHtml

### DIFF
--- a/frontend/src/routes/(admin)/oauth/authorize/index.tsx
+++ b/frontend/src/routes/(admin)/oauth/authorize/index.tsx
@@ -14,7 +14,9 @@ export const clientLoader = loader$<Promise<Client>, { DATABASE: D1Database }>(a
 	let client: Client | null = null
 	try {
 		client = await getClientById(platform.DATABASE, client_id)
-	} catch {
+	} catch (e: unknown) {
+		const error = e as { stack: string; cause: string }
+		console.warn(error.stack, error.cause)
 		throw html(500, getErrorHtml('An error occurred while trying to fetch the client data, please try again later'))
 	}
 	if (client === null) {
@@ -36,8 +38,9 @@ export const userLoader = loader$<
 		// TODO: eventually, verify the JWT with Access, however this
 		// is not critical.
 		payload = access.getPayload(jwt.value)
-	} catch (err: unknown) {
-		console.warn((err as { stack: unknown }).stack)
+	} catch (e: unknown) {
+		const error = e as { stack: string; cause: string }
+		console.warn(error.stack, error.cause)
 		throw html(500, getErrorHtml('Failed to validate Access JWT'))
 	}
 

--- a/frontend/src/routes/(frontend)/[accountId]/[statusId]/index.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/[statusId]/index.tsx
@@ -19,7 +19,9 @@ export const statusLoader = loader$<
 	try {
 		const statusResponse = await statusAPI.handleRequestGet(platform.DATABASE, params.statusId, domain, {} as Person)
 		statusText = await statusResponse.text()
-	} catch {
+	} catch (e: unknown) {
+		const error = e as { stack: string; cause: string }
+		console.warn(error.stack, error.cause)
 		throw html(500, getErrorHtml('An error occurred whilst retrieving the status data, please try again later'))
 	}
 	if (!statusText) {
@@ -36,7 +38,9 @@ export const statusLoader = loader$<
 			throw new Error(`No context present for status with ${params.statusId}`)
 		}
 		return { status, statusTextContent, context }
-	} catch {
+	} catch (e: unknown) {
+		const error = e as { stack: string; cause: string }
+		console.warn(error.stack, error.cause)
 		throw html(500, getErrorHtml('No context for the status has been found, please try again later'))
 	}
 })

--- a/frontend/src/routes/(frontend)/layout.tsx
+++ b/frontend/src/routes/(frontend)/layout.tsx
@@ -9,6 +9,7 @@ import { WildebeestLogo } from '~/components/MastodonLogo'
 import { getCommitHash } from '~/utils/getCommitHash'
 import { InstanceConfigContext } from '~/utils/instanceConfig'
 import { getDocumentHead } from '~/utils/getDocumentHead'
+import { getErrorHtml } from '~/utils/getErrorHtml/getErrorHtml'
 
 export const instanceLoader = loader$<
 	Promise<InstanceConfig>,
@@ -24,8 +25,10 @@ export const instanceLoader = loader$<
 		const results = await response.text()
 		const json = JSON.parse(results) as InstanceConfig
 		return json
-	} catch {
-		throw html(500, 'An error occurred whilst retrieving the instance details')
+	} catch (e: unknown) {
+		const error = e as { stack: string; cause: string }
+		console.warn(error.stack, error.cause)
+		throw html(500, getErrorHtml('An error occurred whilst retrieving the instance details'))
 	}
 })
 

--- a/frontend/src/routes/(frontend)/public/index.tsx
+++ b/frontend/src/routes/(frontend)/public/index.tsx
@@ -5,6 +5,7 @@ import { DocumentHead, loader$ } from '@builder.io/qwik-city'
 import StickyHeader from '~/components/StickyHeader/StickyHeader'
 import { getDocumentHead } from '~/utils/getDocumentHead'
 import { StatusesPanel } from '~/components/StatusesPanel/StatusesPanel'
+import { getErrorHtml } from '~/utils/getErrorHtml/getErrorHtml'
 
 export const statusesLoader = loader$<Promise<MastodonStatus[]>, { DATABASE: D1Database; domain: string }>(
 	async ({ platform, html }) => {
@@ -14,8 +15,10 @@ export const statusesLoader = loader$<Promise<MastodonStatus[]>, { DATABASE: D1D
 			const results = await response.text()
 			// Manually parse the JSON to ensure that Qwik finds the resulting objects serializable.
 			return JSON.parse(results) as MastodonStatus[]
-		} catch {
-			throw html(500, 'The public timeline is unavailable')
+		} catch (e: unknown) {
+			const error = e as { stack: string; cause: string }
+			console.warn(error.stack, error.cause)
+			throw html(500, getErrorHtml('The public timeline is unavailable'))
 		}
 	}
 )

--- a/frontend/src/routes/(frontend)/public/local/index.tsx
+++ b/frontend/src/routes/(frontend)/public/local/index.tsx
@@ -5,6 +5,7 @@ import { DocumentHead, loader$ } from '@builder.io/qwik-city'
 import StickyHeader from '~/components/StickyHeader/StickyHeader'
 import { getDocumentHead } from '~/utils/getDocumentHead'
 import { StatusesPanel } from '~/components/StatusesPanel/StatusesPanel'
+import { getErrorHtml } from '~/utils/getErrorHtml/getErrorHtml'
 
 export const statusesLoader = loader$<Promise<MastodonStatus[]>, { DATABASE: D1Database; domain: string }>(
 	async ({ platform, html }) => {
@@ -14,8 +15,10 @@ export const statusesLoader = loader$<Promise<MastodonStatus[]>, { DATABASE: D1D
 			const results = await response.text()
 			// Manually parse the JSON to ensure that Qwik finds the resulting objects serializable.
 			return JSON.parse(results) as MastodonStatus[]
-		} catch {
-			throw html(500, 'The local timeline is unavailable')
+		} catch (e: unknown) {
+			const error = e as { stack: string; cause: string }
+			console.warn(error.stack, error.cause)
+			throw html(500, getErrorHtml('The local timeline is unavailable'))
 		}
 	}
 )


### PR DESCRIPTION
Changed to use `getErrorHtml`.

Could you please check this.

| Before | After |
| :--: | :--: |
| ![before](https://user-images.githubusercontent.com/3946829/220956389-b205251b-f991-442f-91f9-cd8c0ea1e21b.png) | ![after](https://user-images.githubusercontent.com/3946829/220956678-66218938-8c1b-484a-a8ff-e1c4682e9031.png) |


The following was used as a reference.

https://github.com/cloudflare/wildebeest/blob/c55b09a7718bb65a7d3410fdfbb9dc7cc369a91a/frontend/src/routes/(frontend)/explore/index.tsx#L17-L20