### PR TITLE
fix DocumentHeadValue being modified as readonly

### DIFF
--- a/frontend/src/utils/getDocumentHead.ts
+++ b/frontend/src/utils/getDocumentHead.ts
@@ -10,6 +10,8 @@ type DocumentHeadData = {
 	}
 }
 
+type NoReadonly<T> = { -readonly [P in keyof T]: NoReadonly<T[P]> }
+
 /**
  * Generates a head to provide to QwikCity
  *
@@ -18,7 +20,7 @@ type DocumentHeadData = {
  * @returns the QwikCity head ready to use
  */
 export function getDocumentHead(data: DocumentHeadData, head?: DocumentHeadValue) {
-	const result: DocumentHeadValue = { meta: [] }
+	const result: NoReadonly<DocumentHeadValue> = { meta: [] }
 
 	const setMeta = (name: string, content: string) => {
 		if (head?.meta?.some((meta) => meta.name === name)) {


### PR DESCRIPTION
Fixing this ts issue:
![Screenshot 2023-02-28 at 11 42 20](https://user-images.githubusercontent.com/61631103/221844347-3e3f7793-d1c9-4d20-9f76-425f2a6700c6.png)

(basically even if I am creating it from scratch the `DocumentHeadValue` has all readonly fields)