### PR TITLE
chore: automatic linting before each pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"jest-environment-miniflare": "^2.11.0",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^2.8.1",
+    "simple-git-hooks": "^2.8.1",
 		"ts-jest": "^29.0.3",
 		"typescript": "^4.9.4",
 		"wrangler": "2.7.1"
@@ -48,5 +49,8 @@
 		"cookie": "^0.5.0",
 		"http-message-signatures": "^0.1.2",
 		"toucan-js": "^3.1.0"
-	}
+	},
+  "simple-git-hooks": {
+    "pre-commit": "yarn lint"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3806,6 +3806,11 @@ simple-get@^4.0.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-git-hooks@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/simple-git-hooks/-/simple-git-hooks-2.8.1.tgz#05e8306f3211d7eee9f5fdb5cc42521280ee82a9"
+  integrity sha512-DYpcVR1AGtSfFUNzlBdHrQGPsOhuuEJ/FkmPOOlFysP60AHd3nsEpkGq/QEOdtUyT1Qhk7w9oLmFoMG+75BDog==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"


### PR DESCRIPTION
This simple GitHook runs the existing `yarn lint` script before each commit, this will help ensure that PRs from Contributors (like me) adhere to this repository's preferred style.