### PR TITLE
fix: non-compliant Mastodon Account endpoints

### DIFF
--- a/backend/src/accounts/getAccount.ts
+++ b/backend/src/accounts/getAccount.ts
@@ -8,6 +8,7 @@ import { queryAcct } from 'wildebeest/backend/src/webfinger/index'
 import { loadExternalMastodonAccount, loadLocalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
 import { MastodonAccount } from '../types'
 import { adjustLocalHostDomain } from '../utils/adjustLocalHostDomain'
+import { findMastodonAccountIDByEmailQuery } from 'wildebeest/backend/src/mastodon/sql/account'
 
 export async function getAccount(domain: string, accountId: string, db: Database): Promise<MastodonAccount | null> {
 	const handle = parseHandle(accountId)
@@ -45,4 +46,10 @@ async function getLocalAccount(domain: string, db: Database, handle: Handle): Pr
 	}
 
 	return await loadLocalMastodonAccount(db, actor)
+}
+
+export async function getAccountByEmail(domain: string, email: string, db: Database): Promise<MastodonAccount | null> {
+	const row: any = await db.prepare(findMastodonAccountIDByEmailQuery).bind(email).first()
+
+	return await getAccount(domain, row?.id, db)
 }

--- a/backend/src/errors/index.ts
+++ b/backend/src/errors/index.ts
@@ -46,6 +46,16 @@ export function internalServerError(): Response {
 	return generateErrorResponse('Internal Server Error', 500)
 }
 
+export function malformedMastodonAccountRequest(id: string): Response {
+	console.warn(`Mastodon account ID is not a numeric value: ${id}`)
+	return resourceNotFound('account', id)
+}
+
+export function malformedMastodonAccountLookup(acct: string): Response {
+	console.warn(`Lookup value is not a username or Webfinger address: '${acct}'`)
+	return resourceNotFound('account', acct)
+}
+
 export function statusNotFound(id: string): Response {
 	return resourceNotFound('status', id)
 }

--- a/backend/src/mastodon/account.ts
+++ b/backend/src/mastodon/account.ts
@@ -1,42 +1,46 @@
 import { MastodonAccount } from 'wildebeest/backend/src/types/account'
 import { unwrapPrivateKey } from 'wildebeest/backend/src/utils/key-ops'
-import { Actor } from '../activitypub/actors'
+import { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import { defaultImages } from 'wildebeest/config/accounts'
 import * as apOutbox from 'wildebeest/backend/src/activitypub/actors/outbox'
 import * as apFollow from 'wildebeest/backend/src/activitypub/actors/follow'
 import { type Database } from 'wildebeest/backend/src/database'
+import { mastodonAccountStatisticsQuery } from 'wildebeest/backend/src/mastodon/sql/account'
 
 function toMastodonAccount(acct: string, res: Actor): MastodonAccount {
-	const avatar = res.icon?.url.toString() ?? defaultImages.avatar
-	const header = res.image?.url.toString() ?? defaultImages.header
+	const avatar: string = res.icon?.url.toString() ?? defaultImages.avatar
+	const header: string = res.image?.url.toString() ?? defaultImages.header
 
 	return {
-		acct,
-
 		id: acct,
 		username: res.preferredUsername || res.name || 'unnamed',
+		acct: acct,
 		url: res.url ? res.url.toString() : '',
+
 		display_name: res.name || res.preferredUsername || '',
 		note: res.summary || '',
-		created_at: res.published || new Date().toISOString(),
-
-		avatar,
+		avatar: avatar,
 		avatar_static: avatar,
-
-		header,
+		header: header,
 		header_static: header,
-
 		locked: false,
+		fields: [],
+		emojis: [],
+
 		bot: false,
-		discoverable: true,
 		group: false,
 
-		emojis: [],
-		fields: [],
+		discoverable: true,
+		noindex: undefined,
+		moved: undefined,
+		suspended: undefined,
+		limited: undefined,
 
+		created_at: res.published || new Date().toISOString(),
+		last_status_at: undefined,
+		statuses_count: 0,
 		followers_count: 0,
 		following_count: 0,
-		statuses_count: 0,
 	}
 }
 
@@ -57,28 +61,11 @@ export async function loadExternalMastodonAccount(
 
 // Load a local user and return it as a MastodonAccount
 export async function loadLocalMastodonAccount(db: Database, res: Actor): Promise<MastodonAccount> {
-	const query = `
-SELECT
-  (SELECT count(*)
-   FROM outbox_objects
-   INNER JOIN objects ON objects.id = outbox_objects.object_id
-   WHERE outbox_objects.actor_id=?
-     AND objects.type = 'Note') AS statuses_count,
-
-  (SELECT count(*)
-   FROM actor_following
-   WHERE actor_following.actor_id=?) AS following_count,
-
-  (SELECT count(*)
-   FROM actor_following
-   WHERE actor_following.target_actor_id=?) AS followers_count
-  `
-
 	// For local user the acct is only the local part of the email address.
 	const acct = res.preferredUsername || 'unknown'
 	const account = toMastodonAccount(acct, res)
 
-	const row: any = await db.prepare(query).bind(res.id.toString(), res.id.toString(), res.id.toString()).first()
+	const row: any = await calculateMastodonAccountStatistic(res.id.toString(), db)
 	account.statuses_count = row.statuses_count
 	account.followers_count = row.followers_count
 	account.following_count = row.following_count
@@ -89,12 +76,21 @@ SELECT
 export async function getSigningKey(instanceKey: string, db: Database, actor: Actor): Promise<CryptoKey> {
 	const stmt = db.prepare('SELECT privkey, privkey_salt FROM actors WHERE id=?').bind(actor.id.toString())
 	const { privkey, privkey_salt } = (await stmt.first()) as any
+	return unwrapPrivateKey(instanceKey, new Uint8Array(privkey), new Uint8Array(privkey_salt))
+}
 
-	if (privkey.buffer && privkey_salt.buffer) {
-		// neon.tech
-		return unwrapPrivateKey(instanceKey, new Uint8Array(privkey.buffer), new Uint8Array(privkey_salt.buffer))
-	} else {
-		// D1
-		return unwrapPrivateKey(instanceKey, new Uint8Array(privkey), new Uint8Array(privkey_salt))
+async function calculateMastodonAccountStatistic(actor_id: string, db: Database): Promise<MastodonAccountStatistics> {
+	const row: any = await db.prepare(mastodonAccountStatisticsQuery).bind(actor_id, actor_id, actor_id).first()
+
+	return {
+		statuses_count: row?.statuses_count ?? 0,
+		followers_count: row?.followers_count ?? 0,
+		following_count: row?.following_count ?? 0,
 	}
+}
+
+type MastodonAccountStatistics = {
+	statuses_count: number
+	followers_count: number
+	following_count: number
 }

--- a/backend/src/mastodon/sql/account.ts
+++ b/backend/src/mastodon/sql/account.ts
@@ -1,0 +1,38 @@
+// Prepared statements for Mastodon Account API endpoints
+export const mastodonAccountStatisticsQuery = `
+SELECT
+  (
+    SELECT COUNT(outbox.object_id)
+    FROM outbox_objects AS outbox
+    LEFT JOIN objects AS notes ON 
+      outbox.target='https://www.w3.org/ns/activitystreams#Public' AND 
+      notes.type = 'Note' AND 
+      outbox.object_id = notes.id
+    WHERE
+      notes.id IS NOT NULL AND
+      outbox.actor_id=?
+    GROUP BY outbox.object_id
+  ) AS statuses_count,
+  (
+    SELECT COUNT(relationships.id)
+    FROM actor_following AS relationships
+    WHERE relationships.target_actor_id=?
+    GROUP BY relationships.id
+  ) AS followers_count,
+  (
+    SELECT COUNT(relationships.id)
+    FROM actor_following AS relationships
+    WHERE relationships.actor_id=?
+    GROUP BY relationships.id
+  ) AS following_count
+;`
+
+export const findMastodonAccountIDByEmailQuery = `
+SELECT
+  id
+FROM actors
+WHERE
+  email=?
+ORDER BY cdate DESC
+LIMIT 1
+;`

--- a/backend/src/types/account.ts
+++ b/backend/src/types/account.ts
@@ -1,3 +1,5 @@
+import { CustomEmoji } from 'wildebeest/backend/src/types/custom_emoji'
+
 // https://docs.joinmastodon.org/entities/Account/
 // https://github.com/mastodon/mastodon-android/blob/master/mastodon/src/main/java/org/joinmastodon/android/model/Account.java
 export interface MastodonAccount {
@@ -5,29 +7,45 @@ export interface MastodonAccount {
 	username: string
 	acct: string
 	url: string
-	display_name: string
-	note: string
 
+	display_name: string
+	note: MastodonHTML
 	avatar: string
 	avatar_static: string
-
 	header: string
 	header_static: string
+	locked: boolean
+	fields: Array<Field>
+	emojis: Array<Emoji>
+
+	bot: boolean
+	group: boolean
+
+	discoverable: boolean
+	noindex?: boolean
+	moved?: MastodonAccount
+	suspended?: boolean
+	limited?: boolean
 
 	created_at: string
-
-	locked?: boolean
-	bot?: boolean
-	discoverable?: boolean
-	group?: boolean
-
+	last_status_at?: string
+	statuses_count: number
 	followers_count: number
 	following_count: number
-	statuses_count: number
-
-	emojis: Array<any>
-	fields: Array<Field>
 }
+
+export type MastodonHTML = string
+export type Emoji = CustomEmoji
+
+// https://docs.joinmastodon.org/entities/Account/#Field
+export type Field = {
+	name: string
+	value: string
+	verified_at?: string
+}
+
+// https://docs.joinmastodon.org/entities/Account/#source-privacy
+export type Privacy = 'public' | 'unlisted' | 'private' | 'direct'
 
 // https://docs.joinmastodon.org/entities/Relationship/
 // https://github.com/mastodon/mastodon-android/blob/master/mastodon/src/main/java/org/joinmastodon/android/model/Relationship.java
@@ -35,19 +53,20 @@ export type Relationship = {
 	id: string
 }
 
-export type Privacy = 'public' | 'unlisted' | 'private' | 'direct'
-
 // https://docs.joinmastodon.org/entities/Account/#CredentialAccount
 export interface CredentialAccount extends MastodonAccount {
-	source: {
-		note: string
-		fields: Array<Field>
-		privacy: Privacy
-		sensitive: boolean
-		language: string
-		follow_requests_count: number
-	}
+	source: Source
 	role: Role
+}
+
+// https://docs.joinmastodon.org/entities/Account/#source
+export type Source = {
+	note: string
+	fields: Array<Field>
+	privacy: Privacy
+	sensitive: boolean
+	language: string
+	follow_requests_count: number
 }
 
 // https://docs.joinmastodon.org/entities/Role/
@@ -63,8 +82,6 @@ export type Role = {
 	updated_at: string
 }
 
-export type Field = {
-	name: string
-	value: string
-	verified_at?: string
+export interface MutedAccount extends MastodonAccount {
+	mute_expires_at: string
 }

--- a/backend/src/types/custom_emoji.ts
+++ b/backend/src/types/custom_emoji.ts
@@ -1,0 +1,8 @@
+// https://docs.joinmastodon.org/entities/CustomEmoji/
+export interface CustomEmoji {
+	shortcode: string
+	url: string
+	static_url: string
+	visible_in_picker: boolean
+	category: string
+}

--- a/backend/src/utils/handle.ts
+++ b/backend/src/utils/handle.ts
@@ -8,3 +8,8 @@ export function urlToHandle(input: URL): string {
 	const localPart = parts[parts.length - 1]
 	return `${localPart}@${host}`
 }
+
+export function isHandle(input: string): boolean {
+	const r: RegExp = /^[A-Za-z0-9_]{1,16}(@[A-Za-z0-9]([A-Za-z0-9-]{1,32})?\.[A-Za-z]{2,16})?$/i
+	return input.search(r) !== -1
+}

--- a/backend/src/utils/id.ts
+++ b/backend/src/utils/id.ts
@@ -1,0 +1,22 @@
+// This method generates a Mastodon-compatible identifier
+// see: https://github.com/mastodon/mastodon/blob/main/lib/mastodon/snowflake.rb
+export function createMastodonId(text: string) {
+	const time_part = BigInt(Date.now()) << 16n
+	const sequence_base = BigInt(
+		'0x' + stringToHex(text + crypto.randomUUID().toString() + time_part.toString()).substring(0, 4)
+	)
+	const tail = (sequence_base + crypto.getRandomValues(new BigUint64Array(1))[0]) & 65535n
+	return (time_part | tail).toString()
+}
+
+const stringToHex = (str: string) => {
+	let hex: string = ''
+	for (let i = 0, l = str.length; i < l; i++) {
+		hex += str.charCodeAt(i).toString(16)
+	}
+	return hex
+}
+
+export function isNumeric(value: any): boolean {
+	return !isNaN(value - parseFloat(value))
+}

--- a/backend/test/mastodon/accounts.spec.ts
+++ b/backend/test/mastodon/accounts.spec.ts
@@ -11,7 +11,7 @@ import * as accounts_followers from 'wildebeest/functions/api/v1/accounts/[id]/f
 import * as accounts_follow from 'wildebeest/functions/api/v1/accounts/[id]/follow'
 import * as accounts_unfollow from 'wildebeest/functions/api/v1/accounts/[id]/unfollow'
 import * as accounts_statuses from 'wildebeest/functions/api/v1/accounts/[id]/statuses'
-import * as accounts_get from 'wildebeest/functions/api/v1/accounts/[id]'
+import * as accounts_lookup from 'wildebeest/functions/api/v1/accounts/lookup'
 import { isUUID, isUrlValid, makeDB, assertCORS, assertJSON, makeQueue } from '../utils'
 import * as accounts_verify_creds from 'wildebeest/functions/api/v1/accounts/verify_credentials'
 import * as accounts_update_creds from 'wildebeest/functions/api/v1/accounts/update_credentials'
@@ -21,6 +21,7 @@ import { insertLike } from 'wildebeest/backend/src/mastodon/like'
 import { insertReblog } from 'wildebeest/backend/src/mastodon/reblog'
 import * as filters from 'wildebeest/functions/api/v1/filters'
 import { createStatus } from 'wildebeest/backend/src/mastodon/status'
+import { actorURL } from 'wildebeest/backend/src/activitypub/actors'
 
 const userKEK = 'test_kek2'
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
@@ -29,1044 +30,1067 @@ const domain = 'cloudflare.com'
 describe('Mastodon APIs', () => {
 	describe('/v1', () => {
 		describe('/accounts', () => {
-			beforeEach(() => {
-				globalThis.fetch = async (input: RequestInfo) => {
-					if (input.toString() === 'https://remote.com/.well-known/webfinger?resource=acct%3Asven%40remote.com') {
-						return new Response(
-							JSON.stringify({
-								links: [
-									{
-										rel: 'self',
-										type: 'application/activity+json',
-										href: 'https://social.com/sven',
-									},
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/sven') {
-						return new Response(
-							JSON.stringify({
-								id: 'sven@remote.com',
-								type: 'Person',
-								preferredUsername: 'sven',
-								name: 'sven ssss',
-
-								icon: { url: 'icon.jpg' },
-								image: { url: 'image.jpg' },
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-			})
-
-			test('missing identity', async () => {
-				const data = {
-					cloudflareAccess: {
-						JWT: {
-							getIdentity() {
-								return null
-							},
-						},
-					},
-				}
-
-				const context: any = { data }
-				const res = await accounts_verify_creds.onRequest(context)
-				assert.equal(res.status, 401)
-			})
-
-			test('verify the credentials', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const connectedActor = actor
-
-				const context: any = { data: { connectedActor }, env: { DATABASE: db } }
-				const res = await accounts_verify_creds.onRequest(context)
-				assert.equal(res.status, 200)
-				assertCORS(res)
-				assertJSON(res)
-
-				const data = await res.json<any>()
-				assert.equal(data.display_name, 'sven')
-				// Mastodon app expects the id to be a number (as string), it uses
-				// it to construct an URL. ActivityPub uses URL as ObjectId so we
-				// make sure we don't return the URL.
-				assert(!isUrlValid(data.id))
-			})
-
-			test('update credentials', async () => {
-				const db = await makeDB()
-				const queue = makeQueue()
-				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-				const updates = new FormData()
-				updates.set('display_name', 'newsven')
-				updates.set('note', 'hein')
-
-				const req = new Request('https://example.com', {
-					method: 'PATCH',
-					body: updates,
-				})
-				const res = await accounts_update_creds.handleRequest(
-					db,
-					req,
-					connectedActor,
-					'CF_ACCOUNT_ID',
-					'CF_API_TOKEN',
-					userKEK,
-					queue
-				)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<any>()
-				assert.equal(data.display_name, 'newsven')
-				assert.equal(data.note, 'hein')
-
-				const updatedActor: any = await getActorById(db, connectedActor.id)
-				assert(updatedActor)
-				assert.equal(updatedActor.name, 'newsven')
-				assert.equal(updatedActor.summary, 'hein')
-			})
-
-			test('update credentials sends update to follower', async () => {
-				const db = await makeDB()
-				const queue = makeQueue()
-				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-				await addFollowing(db, actor2, connectedActor, 'sven2@' + domain)
-				await acceptFollowing(db, actor2, connectedActor)
-
-				const updates = new FormData()
-				updates.set('display_name', 'newsven')
-
-				const req = new Request('https://example.com', {
-					method: 'PATCH',
-					body: updates,
-				})
-				const res = await accounts_update_creds.handleRequest(
-					db,
-					req,
-					connectedActor,
-					'CF_ACCOUNT_ID',
-					'CF_API_TOKEN',
-					userKEK,
-					queue
-				)
-				assert.equal(res.status, 200)
-
-				assert.equal(queue.messages.length, 1)
-
-				assert.equal(queue.messages[0].type, MessageType.Deliver)
-				assert.equal(queue.messages[0].activity.type, 'Update')
-				assert.equal(queue.messages[0].actorId, connectedActor.id.toString())
-				assert.equal(queue.messages[0].toActorId, actor2.id.toString())
-			})
-
-			test('update credentials avatar and header', async () => {
-				globalThis.fetch = async (input: RequestInfo, data: any) => {
-					if (input === 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/images/v1') {
-						assert.equal(data.method, 'POST')
-						const file: any = (data.body as { get: (str: string) => any }).get('file')
-						return new Response(
-							JSON.stringify({
-								success: true,
-								result: {
-									variants: [
-										'https://example.com/' + file.name + '/avatar',
-										'https://example.com/' + file.name + '/header',
-									],
-								},
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const db = await makeDB()
-				const queue = makeQueue()
-				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-				const updates = new FormData()
-				updates.set('avatar', new File(['bytes'], 'selfie.jpg', { type: 'image/jpeg' }))
-				updates.set('header', new File(['bytes2'], 'mountain.jpg', { type: 'image/jpeg' }))
-
-				const req = new Request('https://example.com', {
-					method: 'PATCH',
-					body: updates,
-				})
-				const res = await accounts_update_creds.handleRequest(
-					db,
-					req,
-					connectedActor,
-					'CF_ACCOUNT_ID',
-					'CF_API_TOKEN',
-					userKEK,
-					queue
-				)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<any>()
-				assert.equal(data.avatar, 'https://example.com/selfie.jpg/avatar')
-				assert.equal(data.header, 'https://example.com/mountain.jpg/header')
-			})
-
-			test('get remote actor by id', async () => {
-				globalThis.fetch = async (input: RequestInfo) => {
-					if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asven%40social.com') {
-						return new Response(
-							JSON.stringify({
-								links: [
-									{
-										rel: 'self',
-										type: 'application/activity+json',
-										href: 'https://social.com/someone',
-									},
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/someone') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://social.com/someone',
-								url: 'https://social.com/@someone',
-								type: 'Person',
-								preferredUsername: '<script>bad</script>sven',
-								name: 'Sven <i>Cool<i>',
-								outbox: 'https://social.com/someone/outbox',
-								following: 'https://social.com/someone/following',
-								followers: 'https://social.com/someone/followers',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/someone/following') {
-						return new Response(
-							JSON.stringify({
-								'@context': 'https://www.w3.org/ns/activitystreams',
-								id: 'https://social.com/someone/following',
-								type: 'OrderedCollection',
-								totalItems: 123,
-								first: 'https://social.com/someone/following/page',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/someone/followers') {
-						return new Response(
-							JSON.stringify({
-								'@context': 'https://www.w3.org/ns/activitystreams',
-								id: 'https://social.com/someone/followers',
-								type: 'OrderedCollection',
-								totalItems: 321,
-								first: 'https://social.com/someone/followers/page',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/someone/outbox') {
-						return new Response(
-							JSON.stringify({
-								'@context': 'https://www.w3.org/ns/activitystreams',
-								id: 'https://social.com/someone/outbox',
-								type: 'OrderedCollection',
-								totalItems: 890,
-								first: 'https://social.com/someone/outbox/page',
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const db = await makeDB()
-				const res = await accounts_get.handleRequest(domain, 'sven@social.com', db)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<any>()
-				// Note the sanitization
-				assert.equal(data.username, 'badsven')
-				assert.equal(data.display_name, 'Sven Cool')
-				assert.equal(data.acct, 'sven@social.com')
-
-				assert(isUrlValid(data.url))
-				assert(data.url, 'https://social.com/@someone')
-
-				assert.equal(data.followers_count, 321)
-				assert.equal(data.following_count, 123)
-				assert.equal(data.statuses_count, 890)
-			})
-
-			test('get unknown local actor by id', async () => {
-				const db = await makeDB()
-				const res = await accounts_get.handleRequest(domain, 'sven', db)
-				assert.equal(res.status, 404)
-			})
-
-			test('get local actor by id', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-				const actor3 = await createPerson(domain, db, userKEK, 'sven3@cloudflare.com')
-				await addFollowing(db, actor, actor2, 'sven2@' + domain)
-				await acceptFollowing(db, actor, actor2)
-				await addFollowing(db, actor, actor3, 'sven3@' + domain)
-				await acceptFollowing(db, actor, actor3)
-				await addFollowing(db, actor3, actor, 'sven@' + domain)
-				await acceptFollowing(db, actor3, actor)
-
-				await createStatus(domain, db, actor, 'my first status')
-
-				const res = await accounts_get.handleRequest(domain, 'sven3', db)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<any>()
-				assert.equal(data.username, 'sven3')
-				assert.equal(data.acct, 'sven3')
-				assert.equal(data.followers_count, 1)
-				assert.equal(data.following_count, 1)
-				assert.equal(data.statuses_count, 0)
-				assert(isUrlValid(data.url))
-				assert((data.url as string).includes(domain))
-			})
-
-			test('get local actor statuses', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-				const firstNote = await createStatus(domain, db, actor, 'my first status')
-				await insertLike(db, actor, firstNote)
-				await sleep(10)
-				const secondNote = await createStatus(domain, db, actor, 'my second status')
-				await insertReblog(db, actor, secondNote)
-
-				const req = new Request('https://' + domain)
-				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 2)
-
-				assert(isUUID(data[0].id))
-				assert.equal(data[0].content, 'my second status')
-				assert.equal(data[0].account.acct, 'sven@' + domain)
-				assert.equal(data[0].favourites_count, 0)
-				assert.equal(data[0].reblogs_count, 1)
-				assert.equal(new URL(data[0].uri).pathname, '/ap/o/' + data[0].id)
-				assert.equal(new URL(data[0].url).pathname, '/@sven/' + data[0].id)
-
-				assert(isUUID(data[1].id))
-				assert.equal(data[1].content, 'my first status')
-				assert.equal(data[1].favourites_count, 1)
-				assert.equal(data[1].reblogs_count, 0)
-			})
-
-			test("get local actor statuses doesn't include replies", async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-				const note = await createStatus(domain, db, actor, 'a post')
-
-				await sleep(10)
-
-				await createReply(domain, db, actor, note, 'a reply')
-
-				const req = new Request('https://' + domain)
-				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-
-				// Only 1 post because the reply is hidden
-				assert.equal(data.length, 1)
-			})
-
-			test('get local actor statuses includes media attachements', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-				const properties = { url: 'https://example.com/image.jpg' }
-				const mediaAttachments = [await createImage(domain, db, actor, properties)]
-				await createStatus(domain, db, actor, 'status from actor', mediaAttachments)
-
-				const req = new Request('https://' + domain)
-				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-
-				assert.equal(data.length, 1)
-				assert.equal(data[0].media_attachments.length, 1)
-				assert.equal(data[0].media_attachments[0].type, 'image')
-				assert.equal(data[0].media_attachments[0].url, properties.url)
-			})
-
-			test('get pinned statuses', async () => {
-				const db = await makeDB()
-				await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-				const req = new Request('https://' + domain + '?pinned=true')
-				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 0)
-			})
-
-			test('get local actor statuses with max_id', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				await db
-					.prepare("INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id')")
-					.bind('object1', 'Note', JSON.stringify({ content: 'my first status' }))
-					.run()
-				await db
-					.prepare("INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id2')")
-					.bind('object2', 'Note', JSON.stringify({ content: 'my second status' }))
-					.run()
-				await db
-					.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
-					.bind('outbox1', actor.id.toString(), 'object1', '2022-12-16 08:14:48')
-					.run()
-				await db
-					.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
-					.bind('outbox2', actor.id.toString(), 'object2', '2022-12-16 10:14:48')
-					.run()
-
-				{
-					// Query statuses after object1, should only see object2.
-					const req = new Request('https://' + domain + '?max_id=object1')
-					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-					assert.equal(res.status, 200)
-
-					const data = await res.json<Array<any>>()
-					assert.equal(data.length, 1)
-					assert.equal(data[0].content, 'my second status')
-					assert.equal(data[0].account.acct, 'sven@' + domain)
-				}
-
-				{
-					// Query statuses after object2, nothing is after.
-					const req = new Request('https://' + domain + '?max_id=object2')
-					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-					assert.equal(res.status, 200)
-
-					const data = await res.json<Array<any>>()
-					assert.equal(data.length, 0)
-				}
-			})
-
-			test('get local actor statuses with max_id poiting to unknown id', async () => {
-				const db = await makeDB()
-				const req = new Request('https://' + domain + '?max_id=object1')
-				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-				assert.equal(res.status, 404)
-			})
-
-			test('get remote actor statuses', async () => {
-				const db = await makeDB()
-
-				const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
-
-				const note = await createPublicNote(domain, db, 'my localnote status', actorA, [], {
-					attributedTo: actorA.id.toString(),
-				})
-
-				globalThis.fetch = async (input: RequestInfo) => {
-					if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
-						return new Response(
-							JSON.stringify({
-								links: [
-									{
-										rel: 'self',
-										type: 'application/activity+json',
-										href: 'https://social.com/users/someone',
-									},
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/users/someone') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://social.com/users/someone',
-								type: 'Person',
-								preferredUsername: 'someone',
-								outbox: 'https://social.com/outbox',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/outbox') {
-						return new Response(
-							JSON.stringify({
-								first: 'https://social.com/outbox/page1',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/outbox/page1') {
-						return new Response(
-							JSON.stringify({
-								orderedItems: [
-									{
-										id: 'https://mastodon.social/users/a/statuses/b/activity',
-										type: 'Create',
-										actor: 'https://social.com/users/someone',
-										published: '2022-12-10T23:48:38Z',
-										object: {
-											id: 'https://example.com/object1',
-											type: 'Note',
-											content: '<p>p</p>',
-											attachment: [
-												{
-													type: 'Document',
-													mediaType: 'image/jpeg',
-													url: 'https://example.com/image',
-													name: null,
-													blurhash: 'U48;V;_24mx[_1~p.7%MW9?a-;xtxvWBt6ad',
-													width: 1080,
-													height: 894,
-												},
-												{
-													type: 'Document',
-													mediaType: 'video/mp4',
-													url: 'https://example.com/video',
-													name: null,
-													blurhash: 'UB9jfvtT0gO^N5tSX4XV9uR%^Ni]D%Rj$*nf',
-													width: 1080,
-													height: 616,
-												},
-											],
-										},
-									},
-									{
-										id: 'https://mastodon.social/users/c/statuses/d/activity',
-										type: 'Announce',
-										actor: 'https://social.com/users/someone',
-										published: '2022-12-10T23:48:38Z',
-										object: note.id,
-									},
-								],
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const req = new Request('https://example.com')
-				const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 2)
-				assert.equal(data[0].content, '<p>p</p>')
-				assert.equal(data[0].account.username, 'someone')
-
-				assert.equal(data[0].media_attachments.length, 2)
-				assert.equal(data[0].media_attachments[0].type, 'image')
-				assert.equal(data[0].media_attachments[1].type, 'video')
-
-				// Statuses were imported locally and once was a reblog of an already
-				// existing local object.
-				const row: { count: number } = await db.prepare(`SELECT count(*) as count FROM objects`).first()
-				assert.equal(row.count, 2)
-			})
-
-			test('get remote actor statuses ignoring object that fail to download', async () => {
-				const db = await makeDB()
-
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				await createPublicNote(domain, db, 'my localnote status', actor)
-
-				globalThis.fetch = async (input: RequestInfo) => {
-					if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
-						return new Response(
-							JSON.stringify({
-								links: [
-									{
-										rel: 'self',
-										type: 'application/activity+json',
-										href: 'https://social.com/someone',
-									},
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/someone') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://social.com/someone',
-								type: 'Person',
-								preferredUsername: 'someone',
-								outbox: 'https://social.com/outbox',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://social.com/outbox') {
-						return new Response(
-							JSON.stringify({
-								first: 'https://social.com/outbox/page1',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://nonexistingobject.com/') {
-						return new Response('', { status: 400 })
-					}
-
-					if (input.toString() === 'https://social.com/outbox/page1') {
-						return new Response(
-							JSON.stringify({
-								orderedItems: [
-									{
-										id: 'https://mastodon.social/users/c/statuses/d/activity',
-										type: 'Announce',
-										actor: 'https://mastodon.social/users/someone',
-										published: '2022-12-10T23:48:38Z',
-										object: 'https://nonexistingobject.com',
-									},
-								],
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const req = new Request('https://example.com')
-				const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 0)
-			})
-
-			test('get remote actor followers', async () => {
-				const db = await makeDB()
-				const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
-
-				globalThis.fetch = async (input: RequestInfo) => {
-					if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
-						return new Response(
-							JSON.stringify({
-								links: [
-									{
-										rel: 'self',
-										type: 'application/activity+json',
-										href: 'https://example.com/users/sven',
-									},
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/sven') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://example.com/users/sven',
-								type: 'Person',
-								followers: 'https://example.com/users/sven/followers',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/sven/followers') {
-						return new Response(
-							JSON.stringify({
-								'@context': 'https://www.w3.org/ns/activitystreams',
-								id: 'https://example.com/users/sven/followers',
-								type: 'OrderedCollection',
-								totalItems: 3,
-								first: 'https://example.com/users/sven/followers/1',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/sven/followers/1') {
-						return new Response(
-							JSON.stringify({
-								'@context': 'https://www.w3.org/ns/activitystreams',
-								id: 'https://example.com/users/sven/followers/1',
-								type: 'OrderedCollectionPage',
-								totalItems: 3,
-								partOf: 'https://example.com/users/sven/followers',
-								orderedItems: [
-									actorA.id.toString(), // local user
-									'https://example.com/users/b', // remote user
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/b') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://example.com/users/b',
-								type: 'Person',
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const req = new Request(`https://${domain}`)
-				const res = await accounts_followers.handleRequest(req, db, 'sven@example.com')
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 2)
-
-				assert.equal(data[0].acct, 'a@cloudflare.com')
-				assert.equal(data[1].acct, 'b@example.com')
-			})
-
-			test('get local actor followers', async () => {
-				globalThis.fetch = async (input: any) => {
-					if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://example.com/actor',
-								type: 'Person',
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-				await addFollowing(db, actor2, actor, 'sven@' + domain)
-				await acceptFollowing(db, actor2, actor)
-
-				const req = new Request(`https://${domain}`)
-				const res = await accounts_followers.handleRequest(req, db, 'sven')
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 1)
-			})
-
-			test('get local actor following', async () => {
-				globalThis.fetch = async (input: any) => {
-					if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://example.com/foo',
-								type: 'Person',
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-				await addFollowing(db, actor, actor2, 'sven@' + domain)
-				await acceptFollowing(db, actor, actor2)
-
-				const req = new Request(`https://${domain}`)
-				const res = await accounts_following.handleRequest(req, db, 'sven')
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 1)
-			})
-
-			test('get remote actor following', async () => {
-				const db = await makeDB()
-				const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
-
-				globalThis.fetch = async (input: RequestInfo) => {
-					if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
-						return new Response(
-							JSON.stringify({
-								links: [
-									{
-										rel: 'self',
-										type: 'application/activity+json',
-										href: 'https://example.com/users/sven',
-									},
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/sven') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://example.com/users/sven',
-								type: 'Person',
-								following: 'https://example.com/users/sven/following',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/sven/following') {
-						return new Response(
-							JSON.stringify({
-								'@context': 'https://www.w3.org/ns/activitystreams',
-								id: 'https://example.com/users/sven/following',
-								type: 'OrderedCollection',
-								totalItems: 3,
-								first: 'https://example.com/users/sven/following/1',
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/sven/following/1') {
-						return new Response(
-							JSON.stringify({
-								'@context': 'https://www.w3.org/ns/activitystreams',
-								id: 'https://example.com/users/sven/following/1',
-								type: 'OrderedCollectionPage',
-								totalItems: 3,
-								partOf: 'https://example.com/users/sven/following',
-								orderedItems: [
-									actorA.id.toString(), // local user
-									'https://example.com/users/b', // remote user
-								],
-							})
-						)
-					}
-
-					if (input.toString() === 'https://example.com/users/b') {
-						return new Response(
-							JSON.stringify({
-								id: 'https://example.com/users/b',
-								type: 'Person',
-							})
-						)
-					}
-
-					throw new Error('unexpected request to ' + input)
-				}
-
-				const req = new Request(`https://${domain}`)
-				const res = await accounts_following.handleRequest(req, db, 'sven@example.com')
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 2)
-
-				assert.equal(data[0].acct, 'a@cloudflare.com')
-				assert.equal(data[1].acct, 'b@example.com')
-			})
-
-			test('get remote actor featured_tags', async () => {
-				const res = await accounts_featured_tags.onRequest()
-				assert.equal(res.status, 200)
-			})
-
-			test('get remote actor lists', async () => {
-				const res = await accounts_lists.onRequest()
-				assert.equal(res.status, 200)
-			})
-
-			describe('relationships', () => {
-				test('relationships missing ids', async () => {
-					const db = await makeDB()
-					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-					const req = new Request('https://mastodon.example/api/v1/accounts/relationships')
-					const res = await accounts_relationships.handleRequest(req, db, connectedActor)
-					assert.equal(res.status, 400)
-				})
-
-				test('relationships with ids', async () => {
-					const db = await makeDB()
-					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first&id[]=second')
-					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-					const res = await accounts_relationships.handleRequest(req, db, connectedActor)
-					assert.equal(res.status, 200)
-					assertCORS(res)
-					assertJSON(res)
-
-					const data = await res.json<Array<any>>()
-					assert.equal(data.length, 2)
-					assert.equal(data[0].id, 'first')
-					assert.equal(data[0].following, false)
-					assert.equal(data[1].id, 'second')
-					assert.equal(data[1].following, false)
-				})
-
-				test('relationships with one id', async () => {
-					const db = await makeDB()
-					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first')
-					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-					const res = await accounts_relationships.handleRequest(req, db, connectedActor)
-					assert.equal(res.status, 200)
-					assertCORS(res)
-					assertJSON(res)
-
-					const data = await res.json<Array<any>>()
-					assert.equal(data.length, 1)
-					assert.equal(data[0].id, 'first')
-					assert.equal(data[0].following, false)
-				})
-
-				test('relationships following', async () => {
-					const db = await makeDB()
-					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-					await addFollowing(db, actor, actor2, 'sven2@' + domain)
-					await acceptFollowing(db, actor, actor2)
-
-					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
-					const res = await accounts_relationships.handleRequest(req, db, actor)
-					assert.equal(res.status, 200)
-
-					const data = await res.json<Array<any>>()
-					assert.equal(data.length, 1)
-					assert.equal(data[0].following, true)
-				})
-
-				test('relationships following request', async () => {
-					const db = await makeDB()
-					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-					await addFollowing(db, actor, actor2, 'sven2@' + domain)
-
-					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
-					const res = await accounts_relationships.handleRequest(req, db, actor)
-					assert.equal(res.status, 200)
-
-					const data = await res.json<Array<any>>()
-					assert.equal(data.length, 1)
-					assert.equal(data[0].requested, true)
-					assert.equal(data[0].following, false)
-				})
-			})
-
-			test('follow local account', async () => {
-				const db = await makeDB()
-
-				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-				const req = new Request('https://example.com', { method: 'POST' })
-				const res = await accounts_follow.handleRequest(req, db, 'localuser', connectedActor, userKEK)
-				assert.equal(res.status, 403)
-			})
-
-			describe('follow', () => {
-				let receivedActivity: any = null
-
-				beforeEach(() => {
-					receivedActivity = null
-
+			describe('/lookup', () => {
+				test('lookup using remote Mastodon account handle should succeed', async () => {
 					globalThis.fetch = async (input: RequestInfo) => {
-						const request = new Request(input)
-						if (request.url === 'https://' + domain + '/.well-known/webfinger?resource=acct%3Aactor%40' + domain + '') {
+						if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asven%40social.com') {
 							return new Response(
 								JSON.stringify({
 									links: [
 										{
 											rel: 'self',
 											type: 'application/activity+json',
-											href: `https://${domain}/ap/users/actor`,
+											href: 'https://social.com/someone',
 										},
 									],
 								})
 							)
 						}
 
-						if (request.url === `https://${domain}/ap/users/actor`) {
+						if (input.toString() === 'https://social.com/someone') {
 							return new Response(
 								JSON.stringify({
-									id: `https://${domain}/ap/users/actor`,
+									id: 'https://social.com/someone',
+									url: 'https://social.com/@someone',
 									type: 'Person',
-									inbox: `https://${domain}/ap/users/actor/inbox`,
+									preferredUsername: '<script>bad</script>sven',
+									name: 'Sven <i>Cool<i>',
+									outbox: 'https://social.com/someone/outbox',
+									following: 'https://social.com/someone/following',
+									followers: 'https://social.com/someone/followers',
 								})
 							)
 						}
 
-						if (request.url === `https://${domain}/ap/users/actor/inbox`) {
-							assert.equal(request.method, 'POST')
-							receivedActivity = await request.json()
-							return new Response('')
+						if (input.toString() === 'https://social.com/someone/following') {
+							return new Response(
+								JSON.stringify({
+									'@context': 'https://www.w3.org/ns/activitystreams',
+									id: 'https://social.com/someone/following',
+									type: 'OrderedCollection',
+									totalItems: 123,
+									first: 'https://social.com/someone/following/page',
+								})
+							)
 						}
 
-						throw new Error('unexpected request to ' + request.url)
+						if (input.toString() === 'https://social.com/someone/followers') {
+							return new Response(
+								JSON.stringify({
+									'@context': 'https://www.w3.org/ns/activitystreams',
+									id: 'https://social.com/someone/followers',
+									type: 'OrderedCollection',
+									totalItems: 321,
+									first: 'https://social.com/someone/followers/page',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://social.com/someone/outbox') {
+							return new Response(
+								JSON.stringify({
+									'@context': 'https://www.w3.org/ns/activitystreams',
+									id: 'https://social.com/someone/outbox',
+									type: 'OrderedCollection',
+									totalItems: 890,
+									first: 'https://social.com/someone/outbox/page',
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
 					}
+
+					const db = await makeDB()
+					const res = await accounts_lookup.handleRequest(domain, 'sven@social.com', db)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<any>()
+					// Note the sanitization
+					assert.equal(data.username, 'badsven')
+					assert.equal(data.display_name, 'Sven Cool')
+					assert.equal(data.acct, 'sven@social.com')
+
+					assert(isUrlValid(data.url))
+					assert(data.url, 'https://social.com/@someone')
+
+					assert.equal(data.followers_count, 321)
+					assert.equal(data.following_count, 123)
+					assert.equal(data.statuses_count, 890)
 				})
 
-				test('follow account', async () => {
+				test('lookup using local Mastodon account username should succeed', async () => {
 					const db = await makeDB()
 					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+					const actor3 = await createPerson(domain, db, userKEK, 'sven3@cloudflare.com')
+					await addFollowing(db, actor, actor2, 'sven2@' + domain)
+					await acceptFollowing(db, actor, actor2)
+					await addFollowing(db, actor, actor3, 'sven3@' + domain)
+					await acceptFollowing(db, actor, actor3)
+					await addFollowing(db, actor3, actor, 'sven@' + domain)
+					await acceptFollowing(db, actor3, actor)
 
-					const connectedActor = actor
+					await createStatus(domain, db, actor, 'my first status')
 
-					const req = new Request('https://example.com', { method: 'POST' })
-					const res = await accounts_follow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
+					const res = await accounts_lookup.handleRequest(domain, 'sven3', db)
 					assert.equal(res.status, 200)
-					assertCORS(res)
-					assertJSON(res)
 
-					assert(receivedActivity)
-					assert.equal(receivedActivity.type, 'Follow')
-
-					const row: {
-						target_actor_acct: string
-						target_actor_id: string
-						state: string
-					} = await db
-						.prepare(`SELECT target_actor_acct, target_actor_id, state FROM actor_following WHERE actor_id=?`)
-						.bind(actor.id.toString())
-						.first()
-					assert(row)
-					assert.equal(row.target_actor_acct, 'actor@' + domain)
-					assert.equal(row.target_actor_id, `https://${domain}/ap/users/actor`)
-					assert.equal(row.state, 'pending')
+					const data = await res.json<any>()
+					assert.equal(data.username, 'sven3')
+					assert.equal(data.acct, 'sven3')
+					assert.equal(data.followers_count, 1)
+					assert.equal(data.following_count, 1)
+					assert.equal(data.statuses_count, 0)
+					assert(isUrlValid(data.url))
+					assert((data.url as string).includes(domain))
 				})
 
-				test('unfollow account', async () => {
+				test('lookup using unknown local Mastodon account username should fail', async () => {
 					const db = await makeDB()
-					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-					const follower = await createPerson(domain, db, userKEK, 'actor@cloudflare.com')
-					await addFollowing(db, actor, follower, 'not needed')
+					const res = await accounts_lookup.handleRequest(domain, 'sven', db)
+					assert.equal(res.status, 404)
+				})
 
-					const connectedActor = actor
+				test('lookup using Mastodon ID should fail', async () => {
+					const db = await makeDB()
+					const res = await accounts_lookup.handleRequest(domain, '12339500194940588', db)
+					assert.equal(res.status, 404)
+				})
 
-					const req = new Request('https://' + domain, { method: 'POST' })
-					const res = await accounts_unfollow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
-					assert.equal(res.status, 200)
-					assertCORS(res)
-					assertJSON(res)
-
-					assert(receivedActivity)
-					assert.equal(receivedActivity.type, 'Undo')
-					assert.equal(receivedActivity.object.type, 'Follow')
-
-					const row = await db
-						.prepare(`SELECT count(*) as count FROM actor_following WHERE actor_id=?`)
-						.bind(actor.id.toString())
-						.first<{ count: number }>()
-					assert(row)
-					assert.equal(row.count, 0)
+				test('lookup using ActivityPub ID should fail', async () => {
+					const db = await makeDB()
+					const res = await accounts_lookup.handleRequest(domain, actorURL(domain, 'sven').toString(), db)
+					assert.equal(res.status, 404)
 				})
 			})
 
-			test('view filters return empty array', async () => {
-				const res = await filters.onRequest()
-				assert.equal(res.status, 200)
-				assertJSON(res)
+			describe('/id', () => {
+				beforeEach(() => {
+					globalThis.fetch = async (input: RequestInfo) => {
+						if (input.toString() === 'https://remote.com/.well-known/webfinger?resource=acct%3Asven%40remote.com') {
+							return new Response(
+								JSON.stringify({
+									links: [
+										{
+											rel: 'self',
+											type: 'application/activity+json',
+											href: 'https://social.com/sven',
+										},
+									],
+								})
+							)
+						}
 
-				const data = await res.json<any>()
-				assert.equal(data.length, 0)
+						if (input.toString() === 'https://social.com/sven') {
+							return new Response(
+								JSON.stringify({
+									id: 'sven@remote.com',
+									type: 'Person',
+									preferredUsername: 'sven',
+									name: 'sven ssss',
+
+									icon: { url: 'icon.jpg' },
+									image: { url: 'image.jpg' },
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+				})
+
+				test('missing identity', async () => {
+					const data = {
+						cloudflareAccess: {
+							JWT: {
+								getIdentity() {
+									return null
+								},
+							},
+						},
+					}
+
+					const context: any = { data }
+					const res = await accounts_verify_creds.onRequest(context)
+					assert.equal(res.status, 401)
+				})
+
+				test('verify the credentials', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const connectedActor = actor
+
+					const context: any = { data: { connectedActor }, env: { DATABASE: db } }
+					const res = await accounts_verify_creds.onRequest(context)
+					assert.equal(res.status, 200)
+					assertCORS(res)
+					assertJSON(res)
+
+					const data = await res.json<any>()
+					assert.equal(data.display_name, 'sven')
+					// Mastodon app expects the id to be a number (as string), it uses
+					// it to construct an URL. ActivityPub uses URL as ObjectId so we
+					// make sure we don't return the URL.
+					assert(!isUrlValid(data.id))
+				})
+
+				test('update credentials', async () => {
+					const db = await makeDB()
+					const queue = makeQueue()
+					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const updates = new FormData()
+					updates.set('display_name', 'newsven')
+					updates.set('note', 'hein')
+
+					const req = new Request('https://example.com', {
+						method: 'PATCH',
+						body: updates,
+					})
+					const res = await accounts_update_creds.handleRequest(
+						db,
+						req,
+						connectedActor,
+						'CF_ACCOUNT_ID',
+						'CF_API_TOKEN',
+						userKEK,
+						queue
+					)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<any>()
+					assert.equal(data.display_name, 'newsven')
+					assert.equal(data.note, 'hein')
+
+					const updatedActor: any = await getActorById(db, connectedActor.id)
+					assert(updatedActor)
+					assert.equal(updatedActor.name, 'newsven')
+					assert.equal(updatedActor.summary, 'hein')
+				})
+
+				test('update credentials sends update to follower', async () => {
+					const db = await makeDB()
+					const queue = makeQueue()
+					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+					await addFollowing(db, actor2, connectedActor, 'sven2@' + domain)
+					await acceptFollowing(db, actor2, connectedActor)
+
+					const updates = new FormData()
+					updates.set('display_name', 'newsven')
+
+					const req = new Request('https://example.com', {
+						method: 'PATCH',
+						body: updates,
+					})
+					const res = await accounts_update_creds.handleRequest(
+						db,
+						req,
+						connectedActor,
+						'CF_ACCOUNT_ID',
+						'CF_API_TOKEN',
+						userKEK,
+						queue
+					)
+					assert.equal(res.status, 200)
+
+					assert.equal(queue.messages.length, 1)
+
+					assert.equal(queue.messages[0].type, MessageType.Deliver)
+					assert.equal(queue.messages[0].activity.type, 'Update')
+					assert.equal(queue.messages[0].actorId, connectedActor.id.toString())
+					assert.equal(queue.messages[0].toActorId, actor2.id.toString())
+				})
+
+				test('update credentials avatar and header', async () => {
+					globalThis.fetch = async (input: RequestInfo, data: any) => {
+						if (input === 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/images/v1') {
+							assert.equal(data.method, 'POST')
+							const file: any = (data.body as { get: (str: string) => any }).get('file')
+							return new Response(
+								JSON.stringify({
+									success: true,
+									result: {
+										variants: [
+											'https://example.com/' + file.name + '/avatar',
+											'https://example.com/' + file.name + '/header',
+										],
+									},
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+
+					const db = await makeDB()
+					const queue = makeQueue()
+					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const updates = new FormData()
+					updates.set('avatar', new File(['bytes'], 'selfie.jpg', { type: 'image/jpeg' }))
+					updates.set('header', new File(['bytes2'], 'mountain.jpg', { type: 'image/jpeg' }))
+
+					const req = new Request('https://example.com', {
+						method: 'PATCH',
+						body: updates,
+					})
+					const res = await accounts_update_creds.handleRequest(
+						db,
+						req,
+						connectedActor,
+						'CF_ACCOUNT_ID',
+						'CF_API_TOKEN',
+						userKEK,
+						queue
+					)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<any>()
+					assert.equal(data.avatar, 'https://example.com/selfie.jpg/avatar')
+					assert.equal(data.header, 'https://example.com/mountain.jpg/header')
+				})
+
+				test('get local actor statuses', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const firstNote = await createStatus(domain, db, actor, 'my first status')
+					await insertLike(db, actor, firstNote)
+					await sleep(10)
+					const secondNote = await createStatus(domain, db, actor, 'my second status')
+					await insertReblog(db, actor, secondNote)
+
+					const req = new Request('https://' + domain)
+					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 2)
+
+					assert(isUUID(data[0].id))
+					assert.equal(data[0].content, 'my second status')
+					assert.equal(data[0].account.acct, 'sven@' + domain)
+					assert.equal(data[0].favourites_count, 0)
+					assert.equal(data[0].reblogs_count, 1)
+					assert.equal(new URL(data[0].uri).pathname, '/ap/o/' + data[0].id)
+					assert.equal(new URL(data[0].url).pathname, '/@sven/' + data[0].id)
+
+					assert(isUUID(data[1].id))
+					assert.equal(data[1].content, 'my first status')
+					assert.equal(data[1].favourites_count, 1)
+					assert.equal(data[1].reblogs_count, 0)
+				})
+
+				test("get local actor statuses doesn't include replies", async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const note = await createStatus(domain, db, actor, 'a post')
+
+					await sleep(10)
+
+					await createReply(domain, db, actor, note, 'a reply')
+
+					const req = new Request('https://' + domain)
+					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+
+					// Only 1 post because the reply is hidden
+					assert.equal(data.length, 1)
+				})
+
+				test('get local actor statuses includes media attachements', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const properties = { url: 'https://example.com/image.jpg' }
+					const mediaAttachments = [await createImage(domain, db, actor, properties)]
+					await createStatus(domain, db, actor, 'status from actor', mediaAttachments)
+
+					const req = new Request('https://' + domain)
+					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+
+					assert.equal(data.length, 1)
+					assert.equal(data[0].media_attachments.length, 1)
+					assert.equal(data[0].media_attachments[0].type, 'image')
+					assert.equal(data[0].media_attachments[0].url, properties.url)
+				})
+
+				test('get pinned statuses', async () => {
+					const db = await makeDB()
+					await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const req = new Request('https://' + domain + '?pinned=true')
+					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 0)
+				})
+
+				test('get local actor statuses with max_id', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					await db
+						.prepare(
+							"INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id')"
+						)
+						.bind('object1', 'Note', JSON.stringify({ content: 'my first status' }))
+						.run()
+					await db
+						.prepare(
+							"INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id2')"
+						)
+						.bind('object2', 'Note', JSON.stringify({ content: 'my second status' }))
+						.run()
+					await db
+						.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
+						.bind('outbox1', actor.id.toString(), 'object1', '2022-12-16 08:14:48')
+						.run()
+					await db
+						.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
+						.bind('outbox2', actor.id.toString(), 'object2', '2022-12-16 10:14:48')
+						.run()
+
+					{
+						// Query statuses after object1, should only see object2.
+						const req = new Request('https://' + domain + '?max_id=object1')
+						const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+						assert.equal(res.status, 200)
+
+						const data = await res.json<Array<any>>()
+						assert.equal(data.length, 1)
+						assert.equal(data[0].content, 'my second status')
+						assert.equal(data[0].account.acct, 'sven@' + domain)
+					}
+
+					{
+						// Query statuses after object2, nothing is after.
+						const req = new Request('https://' + domain + '?max_id=object2')
+						const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+						assert.equal(res.status, 200)
+
+						const data = await res.json<Array<any>>()
+						assert.equal(data.length, 0)
+					}
+				})
+
+				test('get local actor statuses with max_id poiting to unknown id', async () => {
+					const db = await makeDB()
+					const req = new Request('https://' + domain + '?max_id=object1')
+					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+					assert.equal(res.status, 404)
+				})
+
+				test('get remote actor statuses', async () => {
+					const db = await makeDB()
+
+					const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
+
+					const note = await createPublicNote(domain, db, 'my localnote status', actorA, [], {
+						attributedTo: actorA.id.toString(),
+					})
+
+					globalThis.fetch = async (input: RequestInfo) => {
+						if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
+							return new Response(
+								JSON.stringify({
+									links: [
+										{
+											rel: 'self',
+											type: 'application/activity+json',
+											href: 'https://social.com/users/someone',
+										},
+									],
+								})
+							)
+						}
+
+						if (input.toString() === 'https://social.com/users/someone') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://social.com/users/someone',
+									type: 'Person',
+									preferredUsername: 'someone',
+									outbox: 'https://social.com/outbox',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://social.com/outbox') {
+							return new Response(
+								JSON.stringify({
+									first: 'https://social.com/outbox/page1',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://social.com/outbox/page1') {
+							return new Response(
+								JSON.stringify({
+									orderedItems: [
+										{
+											id: 'https://mastodon.social/users/a/statuses/b/activity',
+											type: 'Create',
+											actor: 'https://social.com/users/someone',
+											published: '2022-12-10T23:48:38Z',
+											object: {
+												id: 'https://example.com/object1',
+												type: 'Note',
+												content: '<p>p</p>',
+												attachment: [
+													{
+														type: 'Document',
+														mediaType: 'image/jpeg',
+														url: 'https://example.com/image',
+														name: null,
+														blurhash: 'U48;V;_24mx[_1~p.7%MW9?a-;xtxvWBt6ad',
+														width: 1080,
+														height: 894,
+													},
+													{
+														type: 'Document',
+														mediaType: 'video/mp4',
+														url: 'https://example.com/video',
+														name: null,
+														blurhash: 'UB9jfvtT0gO^N5tSX4XV9uR%^Ni]D%Rj$*nf',
+														width: 1080,
+														height: 616,
+													},
+												],
+											},
+										},
+										{
+											id: 'https://mastodon.social/users/c/statuses/d/activity',
+											type: 'Announce',
+											actor: 'https://social.com/users/someone',
+											published: '2022-12-10T23:48:38Z',
+											object: note.id,
+										},
+									],
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+
+					const req = new Request('https://example.com')
+					const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 2)
+					assert.equal(data[0].content, '<p>p</p>')
+					assert.equal(data[0].account.username, 'someone')
+
+					assert.equal(data[0].media_attachments.length, 2)
+					assert.equal(data[0].media_attachments[0].type, 'image')
+					assert.equal(data[0].media_attachments[1].type, 'video')
+
+					// Statuses were imported locally and once was a reblog of an already
+					// existing local object.
+					const row: { count: number } = await db.prepare(`SELECT count(*) as count FROM objects`).first()
+					assert.equal(row.count, 2)
+				})
+
+				test('get remote actor statuses ignoring object that fail to download', async () => {
+					const db = await makeDB()
+
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					await createPublicNote(domain, db, 'my localnote status', actor)
+
+					globalThis.fetch = async (input: RequestInfo) => {
+						if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
+							return new Response(
+								JSON.stringify({
+									links: [
+										{
+											rel: 'self',
+											type: 'application/activity+json',
+											href: 'https://social.com/someone',
+										},
+									],
+								})
+							)
+						}
+
+						if (input.toString() === 'https://social.com/someone') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://social.com/someone',
+									type: 'Person',
+									preferredUsername: 'someone',
+									outbox: 'https://social.com/outbox',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://social.com/outbox') {
+							return new Response(
+								JSON.stringify({
+									first: 'https://social.com/outbox/page1',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://nonexistingobject.com/') {
+							return new Response('', { status: 400 })
+						}
+
+						if (input.toString() === 'https://social.com/outbox/page1') {
+							return new Response(
+								JSON.stringify({
+									orderedItems: [
+										{
+											id: 'https://mastodon.social/users/c/statuses/d/activity',
+											type: 'Announce',
+											actor: 'https://mastodon.social/users/someone',
+											published: '2022-12-10T23:48:38Z',
+											object: 'https://nonexistingobject.com',
+										},
+									],
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+
+					const req = new Request('https://example.com')
+					const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 0)
+				})
+
+				test('get remote actor followers', async () => {
+					const db = await makeDB()
+					const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
+
+					globalThis.fetch = async (input: RequestInfo) => {
+						if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
+							return new Response(
+								JSON.stringify({
+									links: [
+										{
+											rel: 'self',
+											type: 'application/activity+json',
+											href: 'https://example.com/users/sven',
+										},
+									],
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/sven') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://example.com/users/sven',
+									type: 'Person',
+									followers: 'https://example.com/users/sven/followers',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/sven/followers') {
+							return new Response(
+								JSON.stringify({
+									'@context': 'https://www.w3.org/ns/activitystreams',
+									id: 'https://example.com/users/sven/followers',
+									type: 'OrderedCollection',
+									totalItems: 3,
+									first: 'https://example.com/users/sven/followers/1',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/sven/followers/1') {
+							return new Response(
+								JSON.stringify({
+									'@context': 'https://www.w3.org/ns/activitystreams',
+									id: 'https://example.com/users/sven/followers/1',
+									type: 'OrderedCollectionPage',
+									totalItems: 3,
+									partOf: 'https://example.com/users/sven/followers',
+									orderedItems: [
+										actorA.id.toString(), // local user
+										'https://example.com/users/b', // remote user
+									],
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/b') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://example.com/users/b',
+									type: 'Person',
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+
+					const req = new Request(`https://${domain}`)
+					const res = await accounts_followers.handleRequest(req, db, 'sven@example.com')
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 2)
+
+					assert.equal(data[0].acct, 'a@cloudflare.com')
+					assert.equal(data[1].acct, 'b@example.com')
+				})
+
+				test('get local actor followers', async () => {
+					globalThis.fetch = async (input: any) => {
+						if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://example.com/actor',
+									type: 'Person',
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+					await addFollowing(db, actor2, actor, 'sven@' + domain)
+					await acceptFollowing(db, actor2, actor)
+
+					const req = new Request(`https://${domain}`)
+					const res = await accounts_followers.handleRequest(req, db, 'sven')
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 1)
+				})
+
+				test('get local actor following', async () => {
+					globalThis.fetch = async (input: any) => {
+						if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://example.com/foo',
+									type: 'Person',
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+					await addFollowing(db, actor, actor2, 'sven@' + domain)
+					await acceptFollowing(db, actor, actor2)
+
+					const req = new Request(`https://${domain}`)
+					const res = await accounts_following.handleRequest(req, db, 'sven')
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 1)
+				})
+
+				test('get remote actor following', async () => {
+					const db = await makeDB()
+					const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
+
+					globalThis.fetch = async (input: RequestInfo) => {
+						if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
+							return new Response(
+								JSON.stringify({
+									links: [
+										{
+											rel: 'self',
+											type: 'application/activity+json',
+											href: 'https://example.com/users/sven',
+										},
+									],
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/sven') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://example.com/users/sven',
+									type: 'Person',
+									following: 'https://example.com/users/sven/following',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/sven/following') {
+							return new Response(
+								JSON.stringify({
+									'@context': 'https://www.w3.org/ns/activitystreams',
+									id: 'https://example.com/users/sven/following',
+									type: 'OrderedCollection',
+									totalItems: 3,
+									first: 'https://example.com/users/sven/following/1',
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/sven/following/1') {
+							return new Response(
+								JSON.stringify({
+									'@context': 'https://www.w3.org/ns/activitystreams',
+									id: 'https://example.com/users/sven/following/1',
+									type: 'OrderedCollectionPage',
+									totalItems: 3,
+									partOf: 'https://example.com/users/sven/following',
+									orderedItems: [
+										actorA.id.toString(), // local user
+										'https://example.com/users/b', // remote user
+									],
+								})
+							)
+						}
+
+						if (input.toString() === 'https://example.com/users/b') {
+							return new Response(
+								JSON.stringify({
+									id: 'https://example.com/users/b',
+									type: 'Person',
+								})
+							)
+						}
+
+						throw new Error('unexpected request to ' + input)
+					}
+
+					const req = new Request(`https://${domain}`)
+					const res = await accounts_following.handleRequest(req, db, 'sven@example.com')
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 2)
+
+					assert.equal(data[0].acct, 'a@cloudflare.com')
+					assert.equal(data[1].acct, 'b@example.com')
+				})
+
+				test('get remote actor featured_tags', async () => {
+					const res = await accounts_featured_tags.onRequest()
+					assert.equal(res.status, 200)
+				})
+
+				test('get remote actor lists', async () => {
+					const res = await accounts_lists.onRequest()
+					assert.equal(res.status, 200)
+				})
+
+				describe('relationships', () => {
+					test('relationships missing ids', async () => {
+						const db = await makeDB()
+						const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+						const req = new Request('https://mastodon.example/api/v1/accounts/relationships')
+						const res = await accounts_relationships.handleRequest(req, db, connectedActor)
+						assert.equal(res.status, 400)
+					})
+
+					test('relationships with ids', async () => {
+						const db = await makeDB()
+						const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first&id[]=second')
+						const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+						const res = await accounts_relationships.handleRequest(req, db, connectedActor)
+						assert.equal(res.status, 200)
+						assertCORS(res)
+						assertJSON(res)
+
+						const data = await res.json<Array<any>>()
+						assert.equal(data.length, 2)
+						assert.equal(data[0].id, 'first')
+						assert.equal(data[0].following, false)
+						assert.equal(data[1].id, 'second')
+						assert.equal(data[1].following, false)
+					})
+
+					test('relationships with one id', async () => {
+						const db = await makeDB()
+						const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first')
+						const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+						const res = await accounts_relationships.handleRequest(req, db, connectedActor)
+						assert.equal(res.status, 200)
+						assertCORS(res)
+						assertJSON(res)
+
+						const data = await res.json<Array<any>>()
+						assert.equal(data.length, 1)
+						assert.equal(data[0].id, 'first')
+						assert.equal(data[0].following, false)
+					})
+
+					test('relationships following', async () => {
+						const db = await makeDB()
+						const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+						const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+						await addFollowing(db, actor, actor2, 'sven2@' + domain)
+						await acceptFollowing(db, actor, actor2)
+
+						const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
+						const res = await accounts_relationships.handleRequest(req, db, actor)
+						assert.equal(res.status, 200)
+
+						const data = await res.json<Array<any>>()
+						assert.equal(data.length, 1)
+						assert.equal(data[0].following, true)
+					})
+
+					test('relationships following request', async () => {
+						const db = await makeDB()
+						const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+						const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+						await addFollowing(db, actor, actor2, 'sven2@' + domain)
+
+						const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
+						const res = await accounts_relationships.handleRequest(req, db, actor)
+						assert.equal(res.status, 200)
+
+						const data = await res.json<Array<any>>()
+						assert.equal(data.length, 1)
+						assert.equal(data[0].requested, true)
+						assert.equal(data[0].following, false)
+					})
+				})
+
+				test('follow local account', async () => {
+					const db = await makeDB()
+
+					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const req = new Request('https://example.com', { method: 'POST' })
+					const res = await accounts_follow.handleRequest(req, db, 'localuser', connectedActor, userKEK)
+					assert.equal(res.status, 403)
+				})
+
+				describe('follow', () => {
+					let receivedActivity: any = null
+
+					beforeEach(() => {
+						receivedActivity = null
+
+						globalThis.fetch = async (input: RequestInfo) => {
+							const request = new Request(input)
+							if (
+								request.url ===
+								'https://' + domain + '/.well-known/webfinger?resource=acct%3Aactor%40' + domain + ''
+							) {
+								return new Response(
+									JSON.stringify({
+										links: [
+											{
+												rel: 'self',
+												type: 'application/activity+json',
+												href: `https://${domain}/ap/users/actor`,
+											},
+										],
+									})
+								)
+							}
+
+							if (request.url === `https://${domain}/ap/users/actor`) {
+								return new Response(
+									JSON.stringify({
+										id: `https://${domain}/ap/users/actor`,
+										type: 'Person',
+										inbox: `https://${domain}/ap/users/actor/inbox`,
+									})
+								)
+							}
+
+							if (request.url === `https://${domain}/ap/users/actor/inbox`) {
+								assert.equal(request.method, 'POST')
+								receivedActivity = await request.json()
+								return new Response('')
+							}
+
+							throw new Error('unexpected request to ' + request.url)
+						}
+					})
+
+					test('follow account', async () => {
+						const db = await makeDB()
+						const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+						const connectedActor = actor
+
+						const req = new Request('https://example.com', { method: 'POST' })
+						const res = await accounts_follow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
+						assert.equal(res.status, 200)
+						assertCORS(res)
+						assertJSON(res)
+
+						assert(receivedActivity)
+						assert.equal(receivedActivity.type, 'Follow')
+
+						const row: {
+							target_actor_acct: string
+							target_actor_id: string
+							state: string
+						} = await db
+							.prepare(`SELECT target_actor_acct, target_actor_id, state FROM actor_following WHERE actor_id=?`)
+							.bind(actor.id.toString())
+							.first()
+						assert(row)
+						assert.equal(row.target_actor_acct, 'actor@' + domain)
+						assert.equal(row.target_actor_id, `https://${domain}/ap/users/actor`)
+						assert.equal(row.state, 'pending')
+					})
+
+					test('unfollow account', async () => {
+						const db = await makeDB()
+						const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+						const follower = await createPerson(domain, db, userKEK, 'actor@cloudflare.com')
+						await addFollowing(db, actor, follower, 'not needed')
+
+						const connectedActor = actor
+
+						const req = new Request('https://' + domain, { method: 'POST' })
+						const res = await accounts_unfollow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
+						assert.equal(res.status, 200)
+						assertCORS(res)
+						assertJSON(res)
+
+						assert(receivedActivity)
+						assert.equal(receivedActivity.type, 'Undo')
+						assert.equal(receivedActivity.object.type, 'Follow')
+
+						const row = await db
+							.prepare(`SELECT count(*) as count FROM actor_following WHERE actor_id=?`)
+							.bind(actor.id.toString())
+							.first<{ count: number }>()
+						assert(row)
+						assert.equal(row.count, 0)
+					})
+				})
+
+				test('view filters return empty array', async () => {
+					const res = await filters.onRequest()
+					assert.equal(res.status, 200)
+					assertJSON(res)
+
+					const data = await res.json<any>()
+					assert.equal(data.length, 0)
+				})
 			})
 		})
 	})

--- a/backend/test/mastodon/accounts.spec.ts
+++ b/backend/test/mastodon/accounts.spec.ts
@@ -27,1045 +27,1047 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 const domain = 'cloudflare.com'
 
 describe('Mastodon APIs', () => {
-	describe('accounts', () => {
-		beforeEach(() => {
-			globalThis.fetch = async (input: RequestInfo) => {
-				if (input.toString() === 'https://remote.com/.well-known/webfinger?resource=acct%3Asven%40remote.com') {
-					return new Response(
-						JSON.stringify({
-							links: [
-								{
-									rel: 'self',
-									type: 'application/activity+json',
-									href: 'https://social.com/sven',
-								},
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/sven') {
-					return new Response(
-						JSON.stringify({
-							id: 'sven@remote.com',
-							type: 'Person',
-							preferredUsername: 'sven',
-							name: 'sven ssss',
-
-							icon: { url: 'icon.jpg' },
-							image: { url: 'image.jpg' },
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-		})
-
-		test('missing identity', async () => {
-			const data = {
-				cloudflareAccess: {
-					JWT: {
-						getIdentity() {
-							return null
-						},
-					},
-				},
-			}
-
-			const context: any = { data }
-			const res = await accounts_verify_creds.onRequest(context)
-			assert.equal(res.status, 401)
-		})
-
-		test('verify the credentials', async () => {
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			const connectedActor = actor
-
-			const context: any = { data: { connectedActor }, env: { DATABASE: db } }
-			const res = await accounts_verify_creds.onRequest(context)
-			assert.equal(res.status, 200)
-			assertCORS(res)
-			assertJSON(res)
-
-			const data = await res.json<any>()
-			assert.equal(data.display_name, 'sven')
-			// Mastodon app expects the id to be a number (as string), it uses
-			// it to construct an URL. ActivityPub uses URL as ObjectId so we
-			// make sure we don't return the URL.
-			assert(!isUrlValid(data.id))
-		})
-
-		test('update credentials', async () => {
-			const db = await makeDB()
-			const queue = makeQueue()
-			const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-			const updates = new FormData()
-			updates.set('display_name', 'newsven')
-			updates.set('note', 'hein')
-
-			const req = new Request('https://example.com', {
-				method: 'PATCH',
-				body: updates,
-			})
-			const res = await accounts_update_creds.handleRequest(
-				db,
-				req,
-				connectedActor,
-				'CF_ACCOUNT_ID',
-				'CF_API_TOKEN',
-				userKEK,
-				queue
-			)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<any>()
-			assert.equal(data.display_name, 'newsven')
-			assert.equal(data.note, 'hein')
-
-			const updatedActor: any = await getActorById(db, connectedActor.id)
-			assert(updatedActor)
-			assert.equal(updatedActor.name, 'newsven')
-			assert.equal(updatedActor.summary, 'hein')
-		})
-
-		test('update credentials sends update to follower', async () => {
-			const db = await makeDB()
-			const queue = makeQueue()
-			const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-			await addFollowing(db, actor2, connectedActor, 'sven2@' + domain)
-			await acceptFollowing(db, actor2, connectedActor)
-
-			const updates = new FormData()
-			updates.set('display_name', 'newsven')
-
-			const req = new Request('https://example.com', {
-				method: 'PATCH',
-				body: updates,
-			})
-			const res = await accounts_update_creds.handleRequest(
-				db,
-				req,
-				connectedActor,
-				'CF_ACCOUNT_ID',
-				'CF_API_TOKEN',
-				userKEK,
-				queue
-			)
-			assert.equal(res.status, 200)
-
-			assert.equal(queue.messages.length, 1)
-
-			assert.equal(queue.messages[0].type, MessageType.Deliver)
-			assert.equal(queue.messages[0].activity.type, 'Update')
-			assert.equal(queue.messages[0].actorId, connectedActor.id.toString())
-			assert.equal(queue.messages[0].toActorId, actor2.id.toString())
-		})
-
-		test('update credentials avatar and header', async () => {
-			globalThis.fetch = async (input: RequestInfo, data: any) => {
-				if (input === 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/images/v1') {
-					assert.equal(data.method, 'POST')
-					const file: any = (data.body as { get: (str: string) => any }).get('file')
-					return new Response(
-						JSON.stringify({
-							success: true,
-							result: {
-								variants: [
-									'https://example.com/' + file.name + '/avatar',
-									'https://example.com/' + file.name + '/header',
-								],
-							},
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const db = await makeDB()
-			const queue = makeQueue()
-			const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-			const updates = new FormData()
-			updates.set('avatar', new File(['bytes'], 'selfie.jpg', { type: 'image/jpeg' }))
-			updates.set('header', new File(['bytes2'], 'mountain.jpg', { type: 'image/jpeg' }))
-
-			const req = new Request('https://example.com', {
-				method: 'PATCH',
-				body: updates,
-			})
-			const res = await accounts_update_creds.handleRequest(
-				db,
-				req,
-				connectedActor,
-				'CF_ACCOUNT_ID',
-				'CF_API_TOKEN',
-				userKEK,
-				queue
-			)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<any>()
-			assert.equal(data.avatar, 'https://example.com/selfie.jpg/avatar')
-			assert.equal(data.header, 'https://example.com/mountain.jpg/header')
-		})
-
-		test('get remote actor by id', async () => {
-			globalThis.fetch = async (input: RequestInfo) => {
-				if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asven%40social.com') {
-					return new Response(
-						JSON.stringify({
-							links: [
-								{
-									rel: 'self',
-									type: 'application/activity+json',
-									href: 'https://social.com/someone',
-								},
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/someone') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://social.com/someone',
-							url: 'https://social.com/@someone',
-							type: 'Person',
-							preferredUsername: '<script>bad</script>sven',
-							name: 'Sven <i>Cool<i>',
-							outbox: 'https://social.com/someone/outbox',
-							following: 'https://social.com/someone/following',
-							followers: 'https://social.com/someone/followers',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/someone/following') {
-					return new Response(
-						JSON.stringify({
-							'@context': 'https://www.w3.org/ns/activitystreams',
-							id: 'https://social.com/someone/following',
-							type: 'OrderedCollection',
-							totalItems: 123,
-							first: 'https://social.com/someone/following/page',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/someone/followers') {
-					return new Response(
-						JSON.stringify({
-							'@context': 'https://www.w3.org/ns/activitystreams',
-							id: 'https://social.com/someone/followers',
-							type: 'OrderedCollection',
-							totalItems: 321,
-							first: 'https://social.com/someone/followers/page',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/someone/outbox') {
-					return new Response(
-						JSON.stringify({
-							'@context': 'https://www.w3.org/ns/activitystreams',
-							id: 'https://social.com/someone/outbox',
-							type: 'OrderedCollection',
-							totalItems: 890,
-							first: 'https://social.com/someone/outbox/page',
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const db = await makeDB()
-			const res = await accounts_get.handleRequest(domain, 'sven@social.com', db)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<any>()
-			// Note the sanitization
-			assert.equal(data.username, 'badsven')
-			assert.equal(data.display_name, 'Sven Cool')
-			assert.equal(data.acct, 'sven@social.com')
-
-			assert(isUrlValid(data.url))
-			assert(data.url, 'https://social.com/@someone')
-
-			assert.equal(data.followers_count, 321)
-			assert.equal(data.following_count, 123)
-			assert.equal(data.statuses_count, 890)
-		})
-
-		test('get unknown local actor by id', async () => {
-			const db = await makeDB()
-			const res = await accounts_get.handleRequest(domain, 'sven', db)
-			assert.equal(res.status, 404)
-		})
-
-		test('get local actor by id', async () => {
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-			const actor3 = await createPerson(domain, db, userKEK, 'sven3@cloudflare.com')
-			await addFollowing(db, actor, actor2, 'sven2@' + domain)
-			await acceptFollowing(db, actor, actor2)
-			await addFollowing(db, actor, actor3, 'sven3@' + domain)
-			await acceptFollowing(db, actor, actor3)
-			await addFollowing(db, actor3, actor, 'sven@' + domain)
-			await acceptFollowing(db, actor3, actor)
-
-			await createStatus(domain, db, actor, 'my first status')
-
-			const res = await accounts_get.handleRequest(domain, 'sven', db)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<any>()
-			assert.equal(data.username, 'sven')
-			assert.equal(data.acct, 'sven')
-			assert.equal(data.followers_count, 1)
-			assert.equal(data.following_count, 2)
-			assert.equal(data.statuses_count, 1)
-			assert(isUrlValid(data.url))
-			assert((data.url as string).includes(domain))
-		})
-
-		test('get local actor statuses', async () => {
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-			const firstNote = await createStatus(domain, db, actor, 'my first status')
-			await insertLike(db, actor, firstNote)
-			await sleep(10)
-			const secondNote = await createStatus(domain, db, actor, 'my second status')
-			await insertReblog(db, actor, secondNote)
-
-			const req = new Request('https://' + domain)
-			const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 2)
-
-			assert(isUUID(data[0].id))
-			assert.equal(data[0].content, 'my second status')
-			assert.equal(data[0].account.acct, 'sven@' + domain)
-			assert.equal(data[0].favourites_count, 0)
-			assert.equal(data[0].reblogs_count, 1)
-			assert.equal(new URL(data[0].uri).pathname, '/ap/o/' + data[0].id)
-			assert.equal(new URL(data[0].url).pathname, '/@sven/' + data[0].id)
-
-			assert(isUUID(data[1].id))
-			assert.equal(data[1].content, 'my first status')
-			assert.equal(data[1].favourites_count, 1)
-			assert.equal(data[1].reblogs_count, 0)
-		})
-
-		test("get local actor statuses doesn't include replies", async () => {
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-			const note = await createStatus(domain, db, actor, 'a post')
-
-			await sleep(10)
-
-			await createReply(domain, db, actor, note, 'a reply')
-
-			const req = new Request('https://' + domain)
-			const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-
-			// Only 1 post because the reply is hidden
-			assert.equal(data.length, 1)
-		})
-
-		test('get local actor statuses includes media attachements', async () => {
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-			const properties = { url: 'https://example.com/image.jpg' }
-			const mediaAttachments = [await createImage(domain, db, actor, properties)]
-			await createStatus(domain, db, actor, 'status from actor', mediaAttachments)
-
-			const req = new Request('https://' + domain)
-			const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-
-			assert.equal(data.length, 1)
-			assert.equal(data[0].media_attachments.length, 1)
-			assert.equal(data[0].media_attachments[0].type, 'image')
-			assert.equal(data[0].media_attachments[0].url, properties.url)
-		})
-
-		test('get pinned statuses', async () => {
-			const db = await makeDB()
-			await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-			const req = new Request('https://' + domain + '?pinned=true')
-			const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 0)
-		})
-
-		test('get local actor statuses with max_id', async () => {
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			await db
-				.prepare("INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id')")
-				.bind('object1', 'Note', JSON.stringify({ content: 'my first status' }))
-				.run()
-			await db
-				.prepare("INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id2')")
-				.bind('object2', 'Note', JSON.stringify({ content: 'my second status' }))
-				.run()
-			await db
-				.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
-				.bind('outbox1', actor.id.toString(), 'object1', '2022-12-16 08:14:48')
-				.run()
-			await db
-				.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
-				.bind('outbox2', actor.id.toString(), 'object2', '2022-12-16 10:14:48')
-				.run()
-
-			{
-				// Query statuses after object1, should only see object2.
-				const req = new Request('https://' + domain + '?max_id=object1')
-				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 1)
-				assert.equal(data[0].content, 'my second status')
-				assert.equal(data[0].account.acct, 'sven@' + domain)
-			}
-
-			{
-				// Query statuses after object2, nothing is after.
-				const req = new Request('https://' + domain + '?max_id=object2')
-				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 0)
-			}
-		})
-
-		test('get local actor statuses with max_id poiting to unknown id', async () => {
-			const db = await makeDB()
-			const req = new Request('https://' + domain + '?max_id=object1')
-			const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
-			assert.equal(res.status, 404)
-		})
-
-		test('get remote actor statuses', async () => {
-			const db = await makeDB()
-
-			const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
-
-			const note = await createPublicNote(domain, db, 'my localnote status', actorA, [], {
-				attributedTo: actorA.id.toString(),
-			})
-
-			globalThis.fetch = async (input: RequestInfo) => {
-				if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
-					return new Response(
-						JSON.stringify({
-							links: [
-								{
-									rel: 'self',
-									type: 'application/activity+json',
-									href: 'https://social.com/users/someone',
-								},
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/users/someone') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://social.com/users/someone',
-							type: 'Person',
-							preferredUsername: 'someone',
-							outbox: 'https://social.com/outbox',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/outbox') {
-					return new Response(
-						JSON.stringify({
-							first: 'https://social.com/outbox/page1',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/outbox/page1') {
-					return new Response(
-						JSON.stringify({
-							orderedItems: [
-								{
-									id: 'https://mastodon.social/users/a/statuses/b/activity',
-									type: 'Create',
-									actor: 'https://social.com/users/someone',
-									published: '2022-12-10T23:48:38Z',
-									object: {
-										id: 'https://example.com/object1',
-										type: 'Note',
-										content: '<p>p</p>',
-										attachment: [
-											{
-												type: 'Document',
-												mediaType: 'image/jpeg',
-												url: 'https://example.com/image',
-												name: null,
-												blurhash: 'U48;V;_24mx[_1~p.7%MW9?a-;xtxvWBt6ad',
-												width: 1080,
-												height: 894,
-											},
-											{
-												type: 'Document',
-												mediaType: 'video/mp4',
-												url: 'https://example.com/video',
-												name: null,
-												blurhash: 'UB9jfvtT0gO^N5tSX4XV9uR%^Ni]D%Rj$*nf',
-												width: 1080,
-												height: 616,
-											},
-										],
-									},
-								},
-								{
-									id: 'https://mastodon.social/users/c/statuses/d/activity',
-									type: 'Announce',
-									actor: 'https://social.com/users/someone',
-									published: '2022-12-10T23:48:38Z',
-									object: note.id,
-								},
-							],
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const req = new Request('https://example.com')
-			const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 2)
-			assert.equal(data[0].content, '<p>p</p>')
-			assert.equal(data[0].account.username, 'someone')
-
-			assert.equal(data[0].media_attachments.length, 2)
-			assert.equal(data[0].media_attachments[0].type, 'image')
-			assert.equal(data[0].media_attachments[1].type, 'video')
-
-			// Statuses were imported locally and once was a reblog of an already
-			// existing local object.
-			const row: { count: number } = await db.prepare(`SELECT count(*) as count FROM objects`).first()
-			assert.equal(row.count, 2)
-		})
-
-		test('get remote actor statuses ignoring object that fail to download', async () => {
-			const db = await makeDB()
-
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			await createPublicNote(domain, db, 'my localnote status', actor)
-
-			globalThis.fetch = async (input: RequestInfo) => {
-				if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
-					return new Response(
-						JSON.stringify({
-							links: [
-								{
-									rel: 'self',
-									type: 'application/activity+json',
-									href: 'https://social.com/someone',
-								},
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/someone') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://social.com/someone',
-							type: 'Person',
-							preferredUsername: 'someone',
-							outbox: 'https://social.com/outbox',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://social.com/outbox') {
-					return new Response(
-						JSON.stringify({
-							first: 'https://social.com/outbox/page1',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://nonexistingobject.com/') {
-					return new Response('', { status: 400 })
-				}
-
-				if (input.toString() === 'https://social.com/outbox/page1') {
-					return new Response(
-						JSON.stringify({
-							orderedItems: [
-								{
-									id: 'https://mastodon.social/users/c/statuses/d/activity',
-									type: 'Announce',
-									actor: 'https://mastodon.social/users/someone',
-									published: '2022-12-10T23:48:38Z',
-									object: 'https://nonexistingobject.com',
-								},
-							],
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const req = new Request('https://example.com')
-			const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 0)
-		})
-
-		test('get remote actor followers', async () => {
-			const db = await makeDB()
-			const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
-
-			globalThis.fetch = async (input: RequestInfo) => {
-				if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
-					return new Response(
-						JSON.stringify({
-							links: [
-								{
-									rel: 'self',
-									type: 'application/activity+json',
-									href: 'https://example.com/users/sven',
-								},
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/sven') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://example.com/users/sven',
-							type: 'Person',
-							followers: 'https://example.com/users/sven/followers',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/sven/followers') {
-					return new Response(
-						JSON.stringify({
-							'@context': 'https://www.w3.org/ns/activitystreams',
-							id: 'https://example.com/users/sven/followers',
-							type: 'OrderedCollection',
-							totalItems: 3,
-							first: 'https://example.com/users/sven/followers/1',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/sven/followers/1') {
-					return new Response(
-						JSON.stringify({
-							'@context': 'https://www.w3.org/ns/activitystreams',
-							id: 'https://example.com/users/sven/followers/1',
-							type: 'OrderedCollectionPage',
-							totalItems: 3,
-							partOf: 'https://example.com/users/sven/followers',
-							orderedItems: [
-								actorA.id.toString(), // local user
-								'https://example.com/users/b', // remote user
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/b') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://example.com/users/b',
-							type: 'Person',
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const req = new Request(`https://${domain}`)
-			const res = await accounts_followers.handleRequest(req, db, 'sven@example.com')
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 2)
-
-			assert.equal(data[0].acct, 'a@cloudflare.com')
-			assert.equal(data[1].acct, 'b@example.com')
-		})
-
-		test('get local actor followers', async () => {
-			globalThis.fetch = async (input: any) => {
-				if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://example.com/actor',
-							type: 'Person',
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-			await addFollowing(db, actor2, actor, 'sven@' + domain)
-			await acceptFollowing(db, actor2, actor)
-
-			const req = new Request(`https://${domain}`)
-			const res = await accounts_followers.handleRequest(req, db, 'sven')
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 1)
-		})
-
-		test('get local actor following', async () => {
-			globalThis.fetch = async (input: any) => {
-				if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://example.com/foo',
-							type: 'Person',
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const db = await makeDB()
-			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-			await addFollowing(db, actor, actor2, 'sven@' + domain)
-			await acceptFollowing(db, actor, actor2)
-
-			const req = new Request(`https://${domain}`)
-			const res = await accounts_following.handleRequest(req, db, 'sven')
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 1)
-		})
-
-		test('get remote actor following', async () => {
-			const db = await makeDB()
-			const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
-
-			globalThis.fetch = async (input: RequestInfo) => {
-				if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
-					return new Response(
-						JSON.stringify({
-							links: [
-								{
-									rel: 'self',
-									type: 'application/activity+json',
-									href: 'https://example.com/users/sven',
-								},
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/sven') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://example.com/users/sven',
-							type: 'Person',
-							following: 'https://example.com/users/sven/following',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/sven/following') {
-					return new Response(
-						JSON.stringify({
-							'@context': 'https://www.w3.org/ns/activitystreams',
-							id: 'https://example.com/users/sven/following',
-							type: 'OrderedCollection',
-							totalItems: 3,
-							first: 'https://example.com/users/sven/following/1',
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/sven/following/1') {
-					return new Response(
-						JSON.stringify({
-							'@context': 'https://www.w3.org/ns/activitystreams',
-							id: 'https://example.com/users/sven/following/1',
-							type: 'OrderedCollectionPage',
-							totalItems: 3,
-							partOf: 'https://example.com/users/sven/following',
-							orderedItems: [
-								actorA.id.toString(), // local user
-								'https://example.com/users/b', // remote user
-							],
-						})
-					)
-				}
-
-				if (input.toString() === 'https://example.com/users/b') {
-					return new Response(
-						JSON.stringify({
-							id: 'https://example.com/users/b',
-							type: 'Person',
-						})
-					)
-				}
-
-				throw new Error('unexpected request to ' + input)
-			}
-
-			const req = new Request(`https://${domain}`)
-			const res = await accounts_following.handleRequest(req, db, 'sven@example.com')
-			assert.equal(res.status, 200)
-
-			const data = await res.json<Array<any>>()
-			assert.equal(data.length, 2)
-
-			assert.equal(data[0].acct, 'a@cloudflare.com')
-			assert.equal(data[1].acct, 'b@example.com')
-		})
-
-		test('get remote actor featured_tags', async () => {
-			const res = await accounts_featured_tags.onRequest()
-			assert.equal(res.status, 200)
-		})
-
-		test('get remote actor lists', async () => {
-			const res = await accounts_lists.onRequest()
-			assert.equal(res.status, 200)
-		})
-
-		describe('relationships', () => {
-			test('relationships missing ids', async () => {
-				const db = await makeDB()
-				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const req = new Request('https://mastodon.example/api/v1/accounts/relationships')
-				const res = await accounts_relationships.handleRequest(req, db, connectedActor)
-				assert.equal(res.status, 400)
-			})
-
-			test('relationships with ids', async () => {
-				const db = await makeDB()
-				const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first&id[]=second')
-				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const res = await accounts_relationships.handleRequest(req, db, connectedActor)
-				assert.equal(res.status, 200)
-				assertCORS(res)
-				assertJSON(res)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 2)
-				assert.equal(data[0].id, 'first')
-				assert.equal(data[0].following, false)
-				assert.equal(data[1].id, 'second')
-				assert.equal(data[1].following, false)
-			})
-
-			test('relationships with one id', async () => {
-				const db = await makeDB()
-				const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first')
-				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const res = await accounts_relationships.handleRequest(req, db, connectedActor)
-				assert.equal(res.status, 200)
-				assertCORS(res)
-				assertJSON(res)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 1)
-				assert.equal(data[0].id, 'first')
-				assert.equal(data[0].following, false)
-			})
-
-			test('relationships following', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-				await addFollowing(db, actor, actor2, 'sven2@' + domain)
-				await acceptFollowing(db, actor, actor2)
-
-				const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
-				const res = await accounts_relationships.handleRequest(req, db, actor)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 1)
-				assert.equal(data[0].following, true)
-			})
-
-			test('relationships following request', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
-				await addFollowing(db, actor, actor2, 'sven2@' + domain)
-
-				const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
-				const res = await accounts_relationships.handleRequest(req, db, actor)
-				assert.equal(res.status, 200)
-
-				const data = await res.json<Array<any>>()
-				assert.equal(data.length, 1)
-				assert.equal(data[0].requested, true)
-				assert.equal(data[0].following, false)
-			})
-		})
-
-		test('follow local account', async () => {
-			const db = await makeDB()
-
-			const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-
-			const req = new Request('https://example.com', { method: 'POST' })
-			const res = await accounts_follow.handleRequest(req, db, 'localuser', connectedActor, userKEK)
-			assert.equal(res.status, 403)
-		})
-
-		describe('follow', () => {
-			let receivedActivity: any = null
-
+	describe('/v1', () => {
+		describe('/accounts', () => {
 			beforeEach(() => {
-				receivedActivity = null
-
 				globalThis.fetch = async (input: RequestInfo) => {
-					const request = new Request(input)
-					if (request.url === 'https://' + domain + '/.well-known/webfinger?resource=acct%3Aactor%40' + domain + '') {
+					if (input.toString() === 'https://remote.com/.well-known/webfinger?resource=acct%3Asven%40remote.com') {
 						return new Response(
 							JSON.stringify({
 								links: [
 									{
 										rel: 'self',
 										type: 'application/activity+json',
-										href: `https://${domain}/ap/users/actor`,
+										href: 'https://social.com/sven',
 									},
 								],
 							})
 						)
 					}
 
-					if (request.url === `https://${domain}/ap/users/actor`) {
+					if (input.toString() === 'https://social.com/sven') {
 						return new Response(
 							JSON.stringify({
-								id: `https://${domain}/ap/users/actor`,
+								id: 'sven@remote.com',
 								type: 'Person',
-								inbox: `https://${domain}/ap/users/actor/inbox`,
+								preferredUsername: 'sven',
+								name: 'sven ssss',
+
+								icon: { url: 'icon.jpg' },
+								image: { url: 'image.jpg' },
 							})
 						)
 					}
 
-					if (request.url === `https://${domain}/ap/users/actor/inbox`) {
-						assert.equal(request.method, 'POST')
-						receivedActivity = await request.json()
-						return new Response('')
-					}
-
-					throw new Error('unexpected request to ' + request.url)
+					throw new Error('unexpected request to ' + input)
 				}
 			})
 
-			test('follow account', async () => {
+			test('missing identity', async () => {
+				const data = {
+					cloudflareAccess: {
+						JWT: {
+							getIdentity() {
+								return null
+							},
+						},
+					},
+				}
+
+				const context: any = { data }
+				const res = await accounts_verify_creds.onRequest(context)
+				assert.equal(res.status, 401)
+			})
+
+			test('verify the credentials', async () => {
+				const db = await makeDB()
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+				const connectedActor = actor
+
+				const context: any = { data: { connectedActor }, env: { DATABASE: db } }
+				const res = await accounts_verify_creds.onRequest(context)
+				assert.equal(res.status, 200)
+				assertCORS(res)
+				assertJSON(res)
+
+				const data = await res.json<any>()
+				assert.equal(data.display_name, 'sven')
+				// Mastodon app expects the id to be a number (as string), it uses
+				// it to construct an URL. ActivityPub uses URL as ObjectId so we
+				// make sure we don't return the URL.
+				assert(!isUrlValid(data.id))
+			})
+
+			test('update credentials', async () => {
+				const db = await makeDB()
+				const queue = makeQueue()
+				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+				const updates = new FormData()
+				updates.set('display_name', 'newsven')
+				updates.set('note', 'hein')
+
+				const req = new Request('https://example.com', {
+					method: 'PATCH',
+					body: updates,
+				})
+				const res = await accounts_update_creds.handleRequest(
+					db,
+					req,
+					connectedActor,
+					'CF_ACCOUNT_ID',
+					'CF_API_TOKEN',
+					userKEK,
+					queue
+				)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<any>()
+				assert.equal(data.display_name, 'newsven')
+				assert.equal(data.note, 'hein')
+
+				const updatedActor: any = await getActorById(db, connectedActor.id)
+				assert(updatedActor)
+				assert.equal(updatedActor.name, 'newsven')
+				assert.equal(updatedActor.summary, 'hein')
+			})
+
+			test('update credentials sends update to follower', async () => {
+				const db = await makeDB()
+				const queue = makeQueue()
+				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+				await addFollowing(db, actor2, connectedActor, 'sven2@' + domain)
+				await acceptFollowing(db, actor2, connectedActor)
+
+				const updates = new FormData()
+				updates.set('display_name', 'newsven')
+
+				const req = new Request('https://example.com', {
+					method: 'PATCH',
+					body: updates,
+				})
+				const res = await accounts_update_creds.handleRequest(
+					db,
+					req,
+					connectedActor,
+					'CF_ACCOUNT_ID',
+					'CF_API_TOKEN',
+					userKEK,
+					queue
+				)
+				assert.equal(res.status, 200)
+
+				assert.equal(queue.messages.length, 1)
+
+				assert.equal(queue.messages[0].type, MessageType.Deliver)
+				assert.equal(queue.messages[0].activity.type, 'Update')
+				assert.equal(queue.messages[0].actorId, connectedActor.id.toString())
+				assert.equal(queue.messages[0].toActorId, actor2.id.toString())
+			})
+
+			test('update credentials avatar and header', async () => {
+				globalThis.fetch = async (input: RequestInfo, data: any) => {
+					if (input === 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/images/v1') {
+						assert.equal(data.method, 'POST')
+						const file: any = (data.body as { get: (str: string) => any }).get('file')
+						return new Response(
+							JSON.stringify({
+								success: true,
+								result: {
+									variants: [
+										'https://example.com/' + file.name + '/avatar',
+										'https://example.com/' + file.name + '/header',
+									],
+								},
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const db = await makeDB()
+				const queue = makeQueue()
+				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+				const updates = new FormData()
+				updates.set('avatar', new File(['bytes'], 'selfie.jpg', { type: 'image/jpeg' }))
+				updates.set('header', new File(['bytes2'], 'mountain.jpg', { type: 'image/jpeg' }))
+
+				const req = new Request('https://example.com', {
+					method: 'PATCH',
+					body: updates,
+				})
+				const res = await accounts_update_creds.handleRequest(
+					db,
+					req,
+					connectedActor,
+					'CF_ACCOUNT_ID',
+					'CF_API_TOKEN',
+					userKEK,
+					queue
+				)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<any>()
+				assert.equal(data.avatar, 'https://example.com/selfie.jpg/avatar')
+				assert.equal(data.header, 'https://example.com/mountain.jpg/header')
+			})
+
+			test('get remote actor by id', async () => {
+				globalThis.fetch = async (input: RequestInfo) => {
+					if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asven%40social.com') {
+						return new Response(
+							JSON.stringify({
+								links: [
+									{
+										rel: 'self',
+										type: 'application/activity+json',
+										href: 'https://social.com/someone',
+									},
+								],
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/someone') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://social.com/someone',
+								url: 'https://social.com/@someone',
+								type: 'Person',
+								preferredUsername: '<script>bad</script>sven',
+								name: 'Sven <i>Cool<i>',
+								outbox: 'https://social.com/someone/outbox',
+								following: 'https://social.com/someone/following',
+								followers: 'https://social.com/someone/followers',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/someone/following') {
+						return new Response(
+							JSON.stringify({
+								'@context': 'https://www.w3.org/ns/activitystreams',
+								id: 'https://social.com/someone/following',
+								type: 'OrderedCollection',
+								totalItems: 123,
+								first: 'https://social.com/someone/following/page',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/someone/followers') {
+						return new Response(
+							JSON.stringify({
+								'@context': 'https://www.w3.org/ns/activitystreams',
+								id: 'https://social.com/someone/followers',
+								type: 'OrderedCollection',
+								totalItems: 321,
+								first: 'https://social.com/someone/followers/page',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/someone/outbox') {
+						return new Response(
+							JSON.stringify({
+								'@context': 'https://www.w3.org/ns/activitystreams',
+								id: 'https://social.com/someone/outbox',
+								type: 'OrderedCollection',
+								totalItems: 890,
+								first: 'https://social.com/someone/outbox/page',
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const db = await makeDB()
+				const res = await accounts_get.handleRequest(domain, 'sven@social.com', db)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<any>()
+				// Note the sanitization
+				assert.equal(data.username, 'badsven')
+				assert.equal(data.display_name, 'Sven Cool')
+				assert.equal(data.acct, 'sven@social.com')
+
+				assert(isUrlValid(data.url))
+				assert(data.url, 'https://social.com/@someone')
+
+				assert.equal(data.followers_count, 321)
+				assert.equal(data.following_count, 123)
+				assert.equal(data.statuses_count, 890)
+			})
+
+			test('get unknown local actor by id', async () => {
+				const db = await makeDB()
+				const res = await accounts_get.handleRequest(domain, 'sven', db)
+				assert.equal(res.status, 404)
+			})
+
+			test('get local actor by id', async () => {
+				const db = await makeDB()
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+				const actor3 = await createPerson(domain, db, userKEK, 'sven3@cloudflare.com')
+				await addFollowing(db, actor, actor2, 'sven2@' + domain)
+				await acceptFollowing(db, actor, actor2)
+				await addFollowing(db, actor, actor3, 'sven3@' + domain)
+				await acceptFollowing(db, actor, actor3)
+				await addFollowing(db, actor3, actor, 'sven@' + domain)
+				await acceptFollowing(db, actor3, actor)
+
+				await createStatus(domain, db, actor, 'my first status')
+
+				const res = await accounts_get.handleRequest(domain, 'sven3', db)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<any>()
+				assert.equal(data.username, 'sven3')
+				assert.equal(data.acct, 'sven3')
+				assert.equal(data.followers_count, 1)
+				assert.equal(data.following_count, 1)
+				assert.equal(data.statuses_count, 0)
+				assert(isUrlValid(data.url))
+				assert((data.url as string).includes(domain))
+			})
+
+			test('get local actor statuses', async () => {
 				const db = await makeDB()
 				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
 
-				const connectedActor = actor
+				const firstNote = await createStatus(domain, db, actor, 'my first status')
+				await insertLike(db, actor, firstNote)
+				await sleep(10)
+				const secondNote = await createStatus(domain, db, actor, 'my second status')
+				await insertReblog(db, actor, secondNote)
+
+				const req = new Request('https://' + domain)
+				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 2)
+
+				assert(isUUID(data[0].id))
+				assert.equal(data[0].content, 'my second status')
+				assert.equal(data[0].account.acct, 'sven@' + domain)
+				assert.equal(data[0].favourites_count, 0)
+				assert.equal(data[0].reblogs_count, 1)
+				assert.equal(new URL(data[0].uri).pathname, '/ap/o/' + data[0].id)
+				assert.equal(new URL(data[0].url).pathname, '/@sven/' + data[0].id)
+
+				assert(isUUID(data[1].id))
+				assert.equal(data[1].content, 'my first status')
+				assert.equal(data[1].favourites_count, 1)
+				assert.equal(data[1].reblogs_count, 0)
+			})
+
+			test("get local actor statuses doesn't include replies", async () => {
+				const db = await makeDB()
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+				const note = await createStatus(domain, db, actor, 'a post')
+
+				await sleep(10)
+
+				await createReply(domain, db, actor, note, 'a reply')
+
+				const req = new Request('https://' + domain)
+				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+
+				// Only 1 post because the reply is hidden
+				assert.equal(data.length, 1)
+			})
+
+			test('get local actor statuses includes media attachements', async () => {
+				const db = await makeDB()
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+				const properties = { url: 'https://example.com/image.jpg' }
+				const mediaAttachments = [await createImage(domain, db, actor, properties)]
+				await createStatus(domain, db, actor, 'status from actor', mediaAttachments)
+
+				const req = new Request('https://' + domain)
+				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+
+				assert.equal(data.length, 1)
+				assert.equal(data[0].media_attachments.length, 1)
+				assert.equal(data[0].media_attachments[0].type, 'image')
+				assert.equal(data[0].media_attachments[0].url, properties.url)
+			})
+
+			test('get pinned statuses', async () => {
+				const db = await makeDB()
+				await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+				const req = new Request('https://' + domain + '?pinned=true')
+				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 0)
+			})
+
+			test('get local actor statuses with max_id', async () => {
+				const db = await makeDB()
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+				await db
+					.prepare("INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id')")
+					.bind('object1', 'Note', JSON.stringify({ content: 'my first status' }))
+					.run()
+				await db
+					.prepare("INSERT INTO objects (id, type, properties, local, mastodon_id) VALUES (?, ?, ?, 1, 'mastodon_id2')")
+					.bind('object2', 'Note', JSON.stringify({ content: 'my second status' }))
+					.run()
+				await db
+					.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
+					.bind('outbox1', actor.id.toString(), 'object1', '2022-12-16 08:14:48')
+					.run()
+				await db
+					.prepare('INSERT INTO outbox_objects (id, actor_id, object_id, cdate) VALUES (?, ?, ?, ?)')
+					.bind('outbox2', actor.id.toString(), 'object2', '2022-12-16 10:14:48')
+					.run()
+
+				{
+					// Query statuses after object1, should only see object2.
+					const req = new Request('https://' + domain + '?max_id=object1')
+					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 1)
+					assert.equal(data[0].content, 'my second status')
+					assert.equal(data[0].account.acct, 'sven@' + domain)
+				}
+
+				{
+					// Query statuses after object2, nothing is after.
+					const req = new Request('https://' + domain + '?max_id=object2')
+					const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 0)
+				}
+			})
+
+			test('get local actor statuses with max_id poiting to unknown id', async () => {
+				const db = await makeDB()
+				const req = new Request('https://' + domain + '?max_id=object1')
+				const res = await accounts_statuses.handleRequest(req, db, 'sven@' + domain)
+				assert.equal(res.status, 404)
+			})
+
+			test('get remote actor statuses', async () => {
+				const db = await makeDB()
+
+				const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
+
+				const note = await createPublicNote(domain, db, 'my localnote status', actorA, [], {
+					attributedTo: actorA.id.toString(),
+				})
+
+				globalThis.fetch = async (input: RequestInfo) => {
+					if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
+						return new Response(
+							JSON.stringify({
+								links: [
+									{
+										rel: 'self',
+										type: 'application/activity+json',
+										href: 'https://social.com/users/someone',
+									},
+								],
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/users/someone') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://social.com/users/someone',
+								type: 'Person',
+								preferredUsername: 'someone',
+								outbox: 'https://social.com/outbox',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/outbox') {
+						return new Response(
+							JSON.stringify({
+								first: 'https://social.com/outbox/page1',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/outbox/page1') {
+						return new Response(
+							JSON.stringify({
+								orderedItems: [
+									{
+										id: 'https://mastodon.social/users/a/statuses/b/activity',
+										type: 'Create',
+										actor: 'https://social.com/users/someone',
+										published: '2022-12-10T23:48:38Z',
+										object: {
+											id: 'https://example.com/object1',
+											type: 'Note',
+											content: '<p>p</p>',
+											attachment: [
+												{
+													type: 'Document',
+													mediaType: 'image/jpeg',
+													url: 'https://example.com/image',
+													name: null,
+													blurhash: 'U48;V;_24mx[_1~p.7%MW9?a-;xtxvWBt6ad',
+													width: 1080,
+													height: 894,
+												},
+												{
+													type: 'Document',
+													mediaType: 'video/mp4',
+													url: 'https://example.com/video',
+													name: null,
+													blurhash: 'UB9jfvtT0gO^N5tSX4XV9uR%^Ni]D%Rj$*nf',
+													width: 1080,
+													height: 616,
+												},
+											],
+										},
+									},
+									{
+										id: 'https://mastodon.social/users/c/statuses/d/activity',
+										type: 'Announce',
+										actor: 'https://social.com/users/someone',
+										published: '2022-12-10T23:48:38Z',
+										object: note.id,
+									},
+								],
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const req = new Request('https://example.com')
+				const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 2)
+				assert.equal(data[0].content, '<p>p</p>')
+				assert.equal(data[0].account.username, 'someone')
+
+				assert.equal(data[0].media_attachments.length, 2)
+				assert.equal(data[0].media_attachments[0].type, 'image')
+				assert.equal(data[0].media_attachments[1].type, 'video')
+
+				// Statuses were imported locally and once was a reblog of an already
+				// existing local object.
+				const row: { count: number } = await db.prepare(`SELECT count(*) as count FROM objects`).first()
+				assert.equal(row.count, 2)
+			})
+
+			test('get remote actor statuses ignoring object that fail to download', async () => {
+				const db = await makeDB()
+
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+				await createPublicNote(domain, db, 'my localnote status', actor)
+
+				globalThis.fetch = async (input: RequestInfo) => {
+					if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
+						return new Response(
+							JSON.stringify({
+								links: [
+									{
+										rel: 'self',
+										type: 'application/activity+json',
+										href: 'https://social.com/someone',
+									},
+								],
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/someone') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://social.com/someone',
+								type: 'Person',
+								preferredUsername: 'someone',
+								outbox: 'https://social.com/outbox',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://social.com/outbox') {
+						return new Response(
+							JSON.stringify({
+								first: 'https://social.com/outbox/page1',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://nonexistingobject.com/') {
+						return new Response('', { status: 400 })
+					}
+
+					if (input.toString() === 'https://social.com/outbox/page1') {
+						return new Response(
+							JSON.stringify({
+								orderedItems: [
+									{
+										id: 'https://mastodon.social/users/c/statuses/d/activity',
+										type: 'Announce',
+										actor: 'https://mastodon.social/users/someone',
+										published: '2022-12-10T23:48:38Z',
+										object: 'https://nonexistingobject.com',
+									},
+								],
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const req = new Request('https://example.com')
+				const res = await accounts_statuses.handleRequest(req, db, 'someone@social.com')
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 0)
+			})
+
+			test('get remote actor followers', async () => {
+				const db = await makeDB()
+				const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
+
+				globalThis.fetch = async (input: RequestInfo) => {
+					if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
+						return new Response(
+							JSON.stringify({
+								links: [
+									{
+										rel: 'self',
+										type: 'application/activity+json',
+										href: 'https://example.com/users/sven',
+									},
+								],
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/sven') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://example.com/users/sven',
+								type: 'Person',
+								followers: 'https://example.com/users/sven/followers',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/sven/followers') {
+						return new Response(
+							JSON.stringify({
+								'@context': 'https://www.w3.org/ns/activitystreams',
+								id: 'https://example.com/users/sven/followers',
+								type: 'OrderedCollection',
+								totalItems: 3,
+								first: 'https://example.com/users/sven/followers/1',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/sven/followers/1') {
+						return new Response(
+							JSON.stringify({
+								'@context': 'https://www.w3.org/ns/activitystreams',
+								id: 'https://example.com/users/sven/followers/1',
+								type: 'OrderedCollectionPage',
+								totalItems: 3,
+								partOf: 'https://example.com/users/sven/followers',
+								orderedItems: [
+									actorA.id.toString(), // local user
+									'https://example.com/users/b', // remote user
+								],
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/b') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://example.com/users/b',
+								type: 'Person',
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const req = new Request(`https://${domain}`)
+				const res = await accounts_followers.handleRequest(req, db, 'sven@example.com')
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 2)
+
+				assert.equal(data[0].acct, 'a@cloudflare.com')
+				assert.equal(data[1].acct, 'b@example.com')
+			})
+
+			test('get local actor followers', async () => {
+				globalThis.fetch = async (input: any) => {
+					if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://example.com/actor',
+								type: 'Person',
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const db = await makeDB()
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+				await addFollowing(db, actor2, actor, 'sven@' + domain)
+				await acceptFollowing(db, actor2, actor)
+
+				const req = new Request(`https://${domain}`)
+				const res = await accounts_followers.handleRequest(req, db, 'sven')
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 1)
+			})
+
+			test('get local actor following', async () => {
+				globalThis.fetch = async (input: any) => {
+					if ((input as object).toString() === 'https://' + domain + '/ap/users/sven2') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://example.com/foo',
+								type: 'Person',
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const db = await makeDB()
+				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+				const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+				await addFollowing(db, actor, actor2, 'sven@' + domain)
+				await acceptFollowing(db, actor, actor2)
+
+				const req = new Request(`https://${domain}`)
+				const res = await accounts_following.handleRequest(req, db, 'sven')
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 1)
+			})
+
+			test('get remote actor following', async () => {
+				const db = await makeDB()
+				const actorA = await createPerson(domain, db, userKEK, 'a@cloudflare.com')
+
+				globalThis.fetch = async (input: RequestInfo) => {
+					if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
+						return new Response(
+							JSON.stringify({
+								links: [
+									{
+										rel: 'self',
+										type: 'application/activity+json',
+										href: 'https://example.com/users/sven',
+									},
+								],
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/sven') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://example.com/users/sven',
+								type: 'Person',
+								following: 'https://example.com/users/sven/following',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/sven/following') {
+						return new Response(
+							JSON.stringify({
+								'@context': 'https://www.w3.org/ns/activitystreams',
+								id: 'https://example.com/users/sven/following',
+								type: 'OrderedCollection',
+								totalItems: 3,
+								first: 'https://example.com/users/sven/following/1',
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/sven/following/1') {
+						return new Response(
+							JSON.stringify({
+								'@context': 'https://www.w3.org/ns/activitystreams',
+								id: 'https://example.com/users/sven/following/1',
+								type: 'OrderedCollectionPage',
+								totalItems: 3,
+								partOf: 'https://example.com/users/sven/following',
+								orderedItems: [
+									actorA.id.toString(), // local user
+									'https://example.com/users/b', // remote user
+								],
+							})
+						)
+					}
+
+					if (input.toString() === 'https://example.com/users/b') {
+						return new Response(
+							JSON.stringify({
+								id: 'https://example.com/users/b',
+								type: 'Person',
+							})
+						)
+					}
+
+					throw new Error('unexpected request to ' + input)
+				}
+
+				const req = new Request(`https://${domain}`)
+				const res = await accounts_following.handleRequest(req, db, 'sven@example.com')
+				assert.equal(res.status, 200)
+
+				const data = await res.json<Array<any>>()
+				assert.equal(data.length, 2)
+
+				assert.equal(data[0].acct, 'a@cloudflare.com')
+				assert.equal(data[1].acct, 'b@example.com')
+			})
+
+			test('get remote actor featured_tags', async () => {
+				const res = await accounts_featured_tags.onRequest()
+				assert.equal(res.status, 200)
+			})
+
+			test('get remote actor lists', async () => {
+				const res = await accounts_lists.onRequest()
+				assert.equal(res.status, 200)
+			})
+
+			describe('relationships', () => {
+				test('relationships missing ids', async () => {
+					const db = await makeDB()
+					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const req = new Request('https://mastodon.example/api/v1/accounts/relationships')
+					const res = await accounts_relationships.handleRequest(req, db, connectedActor)
+					assert.equal(res.status, 400)
+				})
+
+				test('relationships with ids', async () => {
+					const db = await makeDB()
+					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first&id[]=second')
+					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const res = await accounts_relationships.handleRequest(req, db, connectedActor)
+					assert.equal(res.status, 200)
+					assertCORS(res)
+					assertJSON(res)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 2)
+					assert.equal(data[0].id, 'first')
+					assert.equal(data[0].following, false)
+					assert.equal(data[1].id, 'second')
+					assert.equal(data[1].following, false)
+				})
+
+				test('relationships with one id', async () => {
+					const db = await makeDB()
+					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=first')
+					const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const res = await accounts_relationships.handleRequest(req, db, connectedActor)
+					assert.equal(res.status, 200)
+					assertCORS(res)
+					assertJSON(res)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 1)
+					assert.equal(data[0].id, 'first')
+					assert.equal(data[0].following, false)
+				})
+
+				test('relationships following', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+					await addFollowing(db, actor, actor2, 'sven2@' + domain)
+					await acceptFollowing(db, actor, actor2)
+
+					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
+					const res = await accounts_relationships.handleRequest(req, db, actor)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 1)
+					assert.equal(data[0].following, true)
+				})
+
+				test('relationships following request', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const actor2 = await createPerson(domain, db, userKEK, 'sven2@cloudflare.com')
+					await addFollowing(db, actor, actor2, 'sven2@' + domain)
+
+					const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=sven2@' + domain)
+					const res = await accounts_relationships.handleRequest(req, db, actor)
+					assert.equal(res.status, 200)
+
+					const data = await res.json<Array<any>>()
+					assert.equal(data.length, 1)
+					assert.equal(data[0].requested, true)
+					assert.equal(data[0].following, false)
+				})
+			})
+
+			test('follow local account', async () => {
+				const db = await makeDB()
+
+				const connectedActor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
 
 				const req = new Request('https://example.com', { method: 'POST' })
-				const res = await accounts_follow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
-				assert.equal(res.status, 200)
-				assertCORS(res)
-				assertJSON(res)
-
-				assert(receivedActivity)
-				assert.equal(receivedActivity.type, 'Follow')
-
-				const row: {
-					target_actor_acct: string
-					target_actor_id: string
-					state: string
-				} = await db
-					.prepare(`SELECT target_actor_acct, target_actor_id, state FROM actor_following WHERE actor_id=?`)
-					.bind(actor.id.toString())
-					.first()
-				assert(row)
-				assert.equal(row.target_actor_acct, 'actor@' + domain)
-				assert.equal(row.target_actor_id, `https://${domain}/ap/users/actor`)
-				assert.equal(row.state, 'pending')
+				const res = await accounts_follow.handleRequest(req, db, 'localuser', connectedActor, userKEK)
+				assert.equal(res.status, 403)
 			})
 
-			test('unfollow account', async () => {
-				const db = await makeDB()
-				const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-				const follower = await createPerson(domain, db, userKEK, 'actor@cloudflare.com')
-				await addFollowing(db, actor, follower, 'not needed')
+			describe('follow', () => {
+				let receivedActivity: any = null
 
-				const connectedActor = actor
+				beforeEach(() => {
+					receivedActivity = null
 
-				const req = new Request('https://' + domain, { method: 'POST' })
-				const res = await accounts_unfollow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
+					globalThis.fetch = async (input: RequestInfo) => {
+						const request = new Request(input)
+						if (request.url === 'https://' + domain + '/.well-known/webfinger?resource=acct%3Aactor%40' + domain + '') {
+							return new Response(
+								JSON.stringify({
+									links: [
+										{
+											rel: 'self',
+											type: 'application/activity+json',
+											href: `https://${domain}/ap/users/actor`,
+										},
+									],
+								})
+							)
+						}
+
+						if (request.url === `https://${domain}/ap/users/actor`) {
+							return new Response(
+								JSON.stringify({
+									id: `https://${domain}/ap/users/actor`,
+									type: 'Person',
+									inbox: `https://${domain}/ap/users/actor/inbox`,
+								})
+							)
+						}
+
+						if (request.url === `https://${domain}/ap/users/actor/inbox`) {
+							assert.equal(request.method, 'POST')
+							receivedActivity = await request.json()
+							return new Response('')
+						}
+
+						throw new Error('unexpected request to ' + request.url)
+					}
+				})
+
+				test('follow account', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+
+					const connectedActor = actor
+
+					const req = new Request('https://example.com', { method: 'POST' })
+					const res = await accounts_follow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
+					assert.equal(res.status, 200)
+					assertCORS(res)
+					assertJSON(res)
+
+					assert(receivedActivity)
+					assert.equal(receivedActivity.type, 'Follow')
+
+					const row: {
+						target_actor_acct: string
+						target_actor_id: string
+						state: string
+					} = await db
+						.prepare(`SELECT target_actor_acct, target_actor_id, state FROM actor_following WHERE actor_id=?`)
+						.bind(actor.id.toString())
+						.first()
+					assert(row)
+					assert.equal(row.target_actor_acct, 'actor@' + domain)
+					assert.equal(row.target_actor_id, `https://${domain}/ap/users/actor`)
+					assert.equal(row.state, 'pending')
+				})
+
+				test('unfollow account', async () => {
+					const db = await makeDB()
+					const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
+					const follower = await createPerson(domain, db, userKEK, 'actor@cloudflare.com')
+					await addFollowing(db, actor, follower, 'not needed')
+
+					const connectedActor = actor
+
+					const req = new Request('https://' + domain, { method: 'POST' })
+					const res = await accounts_unfollow.handleRequest(req, db, 'actor@' + domain, connectedActor, userKEK)
+					assert.equal(res.status, 200)
+					assertCORS(res)
+					assertJSON(res)
+
+					assert(receivedActivity)
+					assert.equal(receivedActivity.type, 'Undo')
+					assert.equal(receivedActivity.object.type, 'Follow')
+
+					const row = await db
+						.prepare(`SELECT count(*) as count FROM actor_following WHERE actor_id=?`)
+						.bind(actor.id.toString())
+						.first<{ count: number }>()
+					assert(row)
+					assert.equal(row.count, 0)
+				})
+			})
+
+			test('view filters return empty array', async () => {
+				const res = await filters.onRequest()
 				assert.equal(res.status, 200)
-				assertCORS(res)
 				assertJSON(res)
 
-				assert(receivedActivity)
-				assert.equal(receivedActivity.type, 'Undo')
-				assert.equal(receivedActivity.object.type, 'Follow')
-
-				const row = await db
-					.prepare(`SELECT count(*) as count FROM actor_following WHERE actor_id=?`)
-					.bind(actor.id.toString())
-					.first<{ count: number }>()
-				assert(row)
-				assert.equal(row.count, 0)
+				const data = await res.json<any>()
+				assert.equal(data.length, 0)
 			})
-		})
-
-		test('view filters return empty array', async () => {
-			const res = await filters.onRequest()
-			assert.equal(res.status, 200)
-			assertJSON(res)
-
-			const data = await res.json<any>()
-			assert.equal(data.length, 0)
 		})
 	})
 })

--- a/functions/api/v1/accounts/[id].ts
+++ b/functions/api/v1/accounts/[id].ts
@@ -5,6 +5,7 @@ import { cors } from 'wildebeest/backend/src/utils/cors'
 import type { ContextData } from 'wildebeest/backend/src/types/context'
 import type { Env } from 'wildebeest/backend/src/types/env'
 import { getAccount } from 'wildebeest/backend/src/accounts/getAccount'
+import { MastodonAccount } from 'wildebeest/backend/src/types/account'
 
 const headers = {
 	...cors(),
@@ -17,7 +18,7 @@ export const onRequest: PagesFunction<Env, any, ContextData> = async ({ request,
 }
 
 export async function handleRequest(domain: string, id: string, db: Database): Promise<Response> {
-	const account = await getAccount(domain, id, db)
+	const account: MastodonAccount | null = await getAccount(domain, id, db)
 
 	if (account) {
 		return new Response(JSON.stringify(account), { headers })

--- a/functions/api/v1/accounts/lookup.ts
+++ b/functions/api/v1/accounts/lookup.ts
@@ -1,0 +1,38 @@
+// https://docs.joinmastodon.org/methods/accounts/#lookup
+
+import { type Database, getDatabase } from 'wildebeest/backend/src/database'
+import { unprocessableEntity, malformedMastodonAccountLookup } from 'wildebeest/backend/src/errors'
+import { cors } from 'wildebeest/backend/src/utils/cors'
+import type { ContextData } from 'wildebeest/backend/src/types/context'
+import type { Env } from 'wildebeest/backend/src/types/env'
+import { getAccount } from 'wildebeest/backend/src/accounts/getAccount'
+import { isNumeric } from 'wildebeest/backend/src/utils/id'
+import { isHandle } from 'wildebeest/backend/src/utils/handle'
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+export const onRequestGet: PagesFunction<Env, any, ContextData> = async ({ request, env }) => {
+	const requestURL: URL = new URL(request.url)
+	const acct: string | null = requestURL.searchParams?.get('acct')
+	if (!acct) {
+		return unprocessableEntity('`acct` is a required parameter')
+	}
+	return handleRequest(requestURL.hostname, acct, await getDatabase(env))
+}
+
+export async function handleRequest(domain: string, acct: string, db: Database): Promise<Response> {
+	if (isNumeric(acct) || !isHandle(acct)) {
+		return malformedMastodonAccountLookup(acct)
+	}
+
+	const account = await getAccount(domain, acct, db)
+
+	if (account) {
+		return new Response(JSON.stringify(account), { headers })
+	} else {
+		return new Response('', { status: 404 })
+	}
+}


### PR DESCRIPTION
## Completed
- [X] [Define CustomEmoji type](https://github.com/cloudflare/wildebeest/commit/8d9daec481d781f9799fe2e9d736d9c8e08ada96): formally defining this type helps with serialization of a Mastodon API-compliant version of the [Mastodon `Account`](https://docs.joinmastodon.org/entities/Account/) entity
- [X] [Add Mastodon ID utilities](https://github.com/cloudflare/wildebeest/commit/d4ad37573404c471a8a9da59d857c5d6112a77ae): these methods are necessary to generate numeric IDs that resemble those that are used in the [official Mastodon project](https://github.com/mastodon/mastodon/blob/main/lib/mastodon/snowflake.rb). Several of the most popular 3rd-party Mastodon apps, including Ivory, rely on these numeric account IDs. So, these methods lay the foundation for greatly-improved compatibility with 3rd-party apps.
- [X] [MastodonAccount *mostly* aligns w/ Masto API spec](https://github.com/cloudflare/wildebeest/commit/3594448fb333bb11e558d578bfb72556e6a0c3e1) and [Add /api/v1/accounts/lookup + tests](https://github.com/cloudflare/wildebeest/commit/db4a6b4baf1ef1c11a54962f78be6d35efdf3685): these two commits bring the changes in this PR together. One key change here is the addition of the `/api/v1/accounts/lookup` endpoint, which was previously missing, and was contributing to various 3rd-party app incompatibilities. With these changes, I was able to refactor the accounts test suite, which was necessary because 3 tests were miscategorized as belonging to `/api/v1/accounts/:id` when they should have actually been tests for `/api/v1/accounts/lookup`. 

## WIP

- [ ] Generating a Mastodon account ID when an AP actor is added to the `actors` table
- [ ] DB migration to ensure that every entry in the `actors` table has a mastodon id
- [ ] Update the code in `wildebeest/functions/api/v1/accounts/[id].ts` and `wildebeest/functions/api/v1/accounts/[id]/*.ts` so that they actually use the Mastodon Account ID instead of the ActivityPub actor ID because as things stand now, the implementation is not-compliant with the Mastodon API spec, and it's breaking compatibility with several popular 3rd-party apps
- [ ] Update test suite `/api/v1/accounts/:id` endpoints

cc @xtuc 