### PR TITLE
fix SQL is_admin type

### DIFF
--- a/functions/api/wb/settings/server/admins.ts
+++ b/functions/api/wb/settings/server/admins.ts
@@ -15,7 +15,7 @@ export async function handleRequestGet(db: Database) {
 export async function getAdmins(db: Database): Promise<Person[]> {
 	let rows: unknown[] = []
 	try {
-		const stmt = db.prepare('SELECT * FROM actors WHERE is_admin=TRUE')
+		const stmt = db.prepare('SELECT * FROM actors WHERE is_admin=1')
 		const result = await stmt.all<unknown>()
 		rows = result.success ? (result.results as unknown[]) : []
 	} catch {


### PR DESCRIPTION
The `is_admin` column is an `INTEGER`. While SQLite doesn't mind converting `TRUE` to an integer Postgresql is throwing an error.

Switch to `1` which is consistent with the column type.