### PR TITLE
fix: e2e tests fail due to premature timeouts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,14 +19,14 @@ const config: PlaywrightTestConfig = {
 		 * Maximum time expect() should wait for the condition to be met.
 		 * For example in `await expect(locator).toHaveText();`
 		 */
-		timeout: process.env.CI ? 5000 : 500,
+		timeout: (process.env.CI ? 30 : 5) * 1000,
 	},
 	/* Run tests in files in parallel */
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	/* Retry on CI only */
-	retries: process.env.CI ? 3 : 0,
+	retries: process.env.CI ? 1 : 0,
 	/* Opt out of parallel tests on CI. */
 	workers: process.env.CI ? 1 : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -34,7 +34,7 @@ const config: PlaywrightTestConfig = {
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-		actionTimeout: 0,
+		actionTimeout: (process.env.CI ? 30 : 10) * 1000,
 		/* Base URL to use in actions like `await page.goto('/')`. */
 		// baseURL: 'http://localhost:3000',
 


### PR DESCRIPTION
- [X] Fixes timeouts so that tests don't fail on Github Actions runners
- [X] Lowers number of retries so that e2e tests don't run for 2+ hours before giving up
