### PR TITLE
Fix status enrichment that includes URLs with single-letter second-level domains

### DIFF
--- a/backend/src/mastodon/microformats.ts
+++ b/backend/src/mastodon/microformats.ts
@@ -11,7 +11,7 @@ function tag(name: string, content: string, attrs: Record<string, string> = {}):
 	return `<${name}${htmlAttrs}>${content}</${name}>`
 }
 
-const linkRegex = /(^|\s|\b)(https?:\/\/[-\w@:%._+~#=]{2,256}\.[a-z]{2,6}\b(?:[-\w@:%_+.~#?&/=]*))(\b|\s|$)/g
+const linkRegex = /(^|\s|\b)(https?:\/\/[-\w@:%._+~#=]{1,256}\.[a-z]{2,6}\b(?:[-\w@:%_+.~#?&/=]*))(\b|\s|$)/g
 const mentionedEmailRegex = /(^|\s|\b|\W)@(\w+(?:[.-]?\w+)+@\w+(?:[.-]?\w+)+(?:\.\w{2,63})+)(\b|\s|$)/g
 const tagRegex = /(^|\s|\b|\W)#(\w{2,63})(\b|\s|$)/g
 

--- a/backend/test/mastodon.spec.ts
+++ b/backend/test/mastodon.spec.ts
@@ -187,6 +187,9 @@ describe('Mastodon APIs', () => {
 				'http://www.cloudflare.co.uk?test=test@123',
 				'http://www.cloudflare.com/.com/?test=test@~123&a=b',
 				'https://developers.cloudflare.com/workers/runtime-apis/request/#background',
+				'https://a.test',
+				'https://a.test/test',
+				'https://a.test/test?test=test',
 			]
 			linksToTest.forEach((link) => {
 				const url = new URL(link)


### PR DESCRIPTION
This PR fixes #394. Thanks for making great software!