### PR TITLE
remove admin loader and hide not implemented yet

### DIFF
--- a/frontend/src/routes/(admin)/settings/(admin)/layout.tsx
+++ b/frontend/src/routes/(admin)/settings/(admin)/layout.tsx
@@ -1,7 +1,5 @@
 import { component$, Slot } from '@builder.io/qwik'
 
-export { adminLoader } from '~/utils/adminLoader'
-
 export default component$(() => {
 	return (
 		<>

--- a/frontend/src/routes/(admin)/settings/(admin)/migration/index.tsx
+++ b/frontend/src/routes/(admin)/settings/(admin)/migration/index.tsx
@@ -5,6 +5,7 @@ export default component$(() => {
 		<div class="max-w-4xl py-14 px-8">
 			<h2 class="text-2xl font-bold mb-10">Account Migration</h2>
 
+			{/*
 			<div class="text-green-700 mb-10">Your account is not currently being redirected to any other account.</div>
 
 			<h3 class="text-xl mb-6">Move to a different account</h3>
@@ -73,6 +74,7 @@ export default component$(() => {
 				Create Alias
 			</button>
 
+            */}
 			<h3 class="text-xl mt-4 mb-8">Moving from a different account</h3>
 
 			<p class="text-sm text-wildebeest-400 mb-5">

--- a/frontend/src/routes/(admin)/settings/(admin)/server-settings/layout.tsx
+++ b/frontend/src/routes/(admin)/settings/(admin)/server-settings/layout.tsx
@@ -5,6 +5,8 @@ import { getSettings } from 'wildebeest/backend/src/config/server'
 import { ServerAboutData } from './about'
 import { ServerBrandingData } from './branding'
 
+export { adminLoader } from '~/utils/adminLoader'
+
 export type ServerSettingsData = ServerBrandingData & ServerAboutData
 
 export const serverSettingsLoader = loader$<Promise<Partial<ServerSettingsData>>>(async ({ platform }) => {


### PR DESCRIPTION
Any connected user are able to set an alias on their Actor. Set the admin restriction only on server-settings.