### PR TITLE
Use deploy comand instead of deprecated publish command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,7 +181,7 @@ jobs:
         uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
-          command: publish --config do/wrangler.toml
+          command: deploy --config do/wrangler.toml
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
 


### PR DESCRIPTION
I got an error when deploying, I changed to this based on error I got when deploying