### PR TITLE
Use playwright docker image in e2e test

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -55,6 +55,8 @@ jobs:
 
   test-ui:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.30.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,12 +64,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.13.x
+          cache: "yarn"
       - name: Install dependencies
         run: yarn
       - name: Run App in the background
         run: yarn ci-dev-test-ui &
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
       - name: Run Playwright tests
         run: yarn playwright test
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This speeds up the build a lot. Also enabled yarn cache for even faster tests.